### PR TITLE
Fixed type mismatch in models

### DIFF
--- a/betfair/models.py
+++ b/betfair/models.py
@@ -138,7 +138,7 @@ class Match(BetfairModel):
 
 
 class Runner(BetfairModel):
-    selection_id = Field(DataType(float), required=True)
+    selection_id = Field(DataType(six.text_type), required=True)
     handicap = Field(DataType(float), required=True)
     status = Field(EnumType(constants.RunnerStatus), required=True)
     adjustment_factor = Field(DataType(float))
@@ -172,7 +172,7 @@ class MarketBook(BetfairModel):
 
 
 class RunnerProfitAndLoss(BetfairModel):
-    selection_id = Field(DataType(float))
+    selection_id = Field(DataType(six.text_type))
     if_win = Field(DataType(float))
     if_lose = Field(DataType(float))
 
@@ -259,7 +259,7 @@ class VenueResult(BetfairModel):
 
 class PlaceInstruction(BetfairModel):
     order_type = Field(EnumType(constants.OrderType), required=True)
-    selection_id = Field(DataType(float), required=True)
+    selection_id = Field(DataType(six.text_type), required=True)
     handicap = Field(DataType(float))
     side = Field(EnumType(constants.Side), required=True)
     limit_order = Field(ModelType(LimitOrder))
@@ -287,7 +287,7 @@ class UpdateInstruction(BetfairModel):
 class CurrentOrderSummary(BetfairModel):
     bet_id = Field(DataType(six.text_type), required=True)
     market_id = Field(DataType(six.text_type), required=True)
-    selection_id = Field(DataType(float), required=True)
+    selection_id = Field(DataType(six.text_type), required=True)
     handicap = Field(DataType(float), required=True)
     price_size = Field(DataType(PriceSize), required=True)
     bsp_liability = Field(DataType(float), required=True)


### PR DESCRIPTION
Some of the classes had the selection_id as a float and some of them had it as a text. This caused problems when searching and matching by selection_id was performed. Betfair returns (or requires) selectionId as long or SelectionId type (which is a type alias for long, I don't know why this is done).   
