### PR TITLE
Fixed setup.py to work with newer versions of pip

### DIFF
--- a/docs/betfair.betfair.html
+++ b/docs/betfair.betfair.html
@@ -1,0 +1,204 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.betfair</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.betfair</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/betfair.py">/home/james/projects/betfair.py/betfair/betfair.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.exceptions.html">betfair.exceptions</a><br>
+<a href="httplib.html">httplib</a><br>
+<a href="itertools.html">itertools</a><br>
+</td><td width="25%" valign=top><a href="json.html">json</a><br>
+<a href="betfair.models.html">betfair.models</a><br>
+<a href="os.html">os</a><br>
+</td><td width="25%" valign=top><a href="requests.html">requests</a><br>
+<a href="six.moves.urllib_parse.html">six.moves.urllib_parse</a><br>
+<a href="betfair.utils.html">betfair.utils</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="__builtin__.html#object">__builtin__.object</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.betfair.html#Betfair">Betfair</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Betfair">class <strong>Betfair</strong></a>(<a href="__builtin__.html#object">__builtin__.object</a>)</font></td></tr>
+    
+<tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
+<td colspan=2><tt><a href="#Betfair">Betfair</a>&nbsp;API&nbsp;client.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;app_key:&nbsp;Optional&nbsp;application&nbsp;identifier<br>
+:param&nbsp;str&nbsp;cert_file:&nbsp;Path&nbsp;to&nbsp;self-signed&nbsp;SSL&nbsp;certificate&nbsp;file(s);&nbsp;may&nbsp;be<br>
+&nbsp;&nbsp;&nbsp;&nbsp;a&nbsp;*.pem&nbsp;file&nbsp;or&nbsp;a&nbsp;tuple&nbsp;of&nbsp;(*.crt,&nbsp;*.key)&nbsp;files<br>
+:param&nbsp;str&nbsp;content_type:&nbsp;Response&nbsp;type<br>&nbsp;</tt></td></tr>
+<tr><td>&nbsp;</td>
+<td width="100%">Methods defined here:<br>
+<dl><dt><a name="Betfair-__init__"><strong>__init__</strong></a>(self, app_key, cert_file, content_type<font color="#909090">='application/json'</font>)</dt></dl>
+
+<dl><dt><a name="Betfair-cancel_orders"><strong>cancel_orders</strong></a>(self, market_id, instructions, customer_ref<font color="#909090">=None</font>)</dt><dd><tt>Cancel&nbsp;all&nbsp;bets&nbsp;OR&nbsp;cancel&nbsp;all&nbsp;bets&nbsp;on&nbsp;a&nbsp;market&nbsp;OR&nbsp;fully&nbsp;or<br>
+partially&nbsp;cancel&nbsp;particular&nbsp;orders&nbsp;on&nbsp;a&nbsp;market.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;market_id:&nbsp;If&nbsp;not&nbsp;supplied&nbsp;all&nbsp;bets&nbsp;are&nbsp;cancelled<br>
+:param&nbsp;list&nbsp;instructions:&nbsp;List&nbsp;of&nbsp;`CancelInstruction`&nbsp;objects<br>
+:param&nbsp;str&nbsp;customer_ref:&nbsp;Optional&nbsp;order&nbsp;identifier&nbsp;string</tt></dd></dl>
+
+<dl><dt><a name="Betfair-iter_list_market_book"><strong>iter_list_market_book</strong></a>(self, market_ids, chunk_size, **kwargs)</dt><dd><tt>Split&nbsp;call&nbsp;to&nbsp;`list_market_book`&nbsp;into&nbsp;separate&nbsp;requests.<br>
+&nbsp;<br>
+:param&nbsp;list&nbsp;market_ids:&nbsp;List&nbsp;of&nbsp;market&nbsp;IDs<br>
+:param&nbsp;int&nbsp;chunk_size:&nbsp;Number&nbsp;of&nbsp;records&nbsp;per&nbsp;chunk<br>
+:param&nbsp;dict&nbsp;kwargs:&nbsp;Arguments&nbsp;passed&nbsp;to&nbsp;`list_market_book`</tt></dd></dl>
+
+<dl><dt><a name="Betfair-iter_list_market_profit_and_loss"><strong>iter_list_market_profit_and_loss</strong></a>(self, market_ids, chunk_size, **kwargs)</dt><dd><tt>Split&nbsp;call&nbsp;to&nbsp;`list_market_profit_and_loss`&nbsp;into&nbsp;separate&nbsp;requests.<br>
+&nbsp;<br>
+:param&nbsp;list&nbsp;market_ids:&nbsp;List&nbsp;of&nbsp;market&nbsp;IDs<br>
+:param&nbsp;int&nbsp;chunk_size:&nbsp;Number&nbsp;of&nbsp;records&nbsp;per&nbsp;chunk<br>
+:param&nbsp;dict&nbsp;kwargs:&nbsp;Arguments&nbsp;passed&nbsp;to&nbsp;`list_market_profit_and_loss`</tt></dd></dl>
+
+<dl><dt><a name="Betfair-keep_alive"><strong>keep_alive</strong></a>(self)</dt><dd><tt>Reset&nbsp;session&nbsp;timeout.<br>
+&nbsp;<br>
+:raises:&nbsp;BetfairAuthError</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_cleared_orders"><strong>list_cleared_orders</strong></a>(self, bet_status, event_type_ids, event_ids, market_ids, runner_ids, bet_ids, side, settled_date_range, group_by, include_item_description, locale, from_record, record_count)</dt><dd><tt>:param&nbsp;bet_status:<br>
+:param&nbsp;event_type_ids:<br>
+:param&nbsp;event_ids:<br>
+:param&nbsp;market_ids:<br>
+:param&nbsp;runner_ids:<br>
+:param&nbsp;bet_ids:<br>
+:param&nbsp;side:<br>
+:param&nbsp;settled_date_range:<br>
+:param&nbsp;group_by:<br>
+:param&nbsp;include_item_description:<br>
+:param&nbsp;locale:<br>
+:param&nbsp;from_record:<br>
+:param&nbsp;record_count:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_competitions"><strong>list_competitions</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_countries"><strong>list_countries</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_current_orders"><strong>list_current_orders</strong></a>(self, bet_ids, market_ids, order_projection, date_range, order_by, sort_dir, from_record, record_count)</dt><dd><tt>:param&nbsp;bet_ids:<br>
+:param&nbsp;market_ids:<br>
+:param&nbsp;order_projection:<br>
+:param&nbsp;date_range:<br>
+:param&nbsp;order_by:<br>
+:param&nbsp;sort_dir:<br>
+:param&nbsp;from_record:<br>
+:param&nbsp;record_count:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_event_types"><strong>list_event_types</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_events"><strong>list_events</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_market_book"><strong>list_market_book</strong></a>(self, market_ids, price_projection<font color="#909090">=None</font>, order_projection<font color="#909090">=None</font>, match_projection<font color="#909090">=None</font>, currency_code<font color="#909090">=None</font>, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;list&nbsp;market_ids:&nbsp;List&nbsp;of&nbsp;market&nbsp;IDs<br>
+:param&nbsp;PriceProjection&nbsp;price_projection:<br>
+:param&nbsp;OrderProjection&nbsp;order_projection:<br>
+:param&nbsp;MatchProjection&nbsp;match_projection:<br>
+:param&nbsp;str&nbsp;currency_code:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_market_catalogue"><strong>list_market_catalogue</strong></a>(self, filter, max_results<font color="#909090">=100</font>, market_projection<font color="#909090">=None</font>, locale<font color="#909090">=None</font>, sort<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;int&nbsp;max_results:<br>
+:param&nbsp;list&nbsp;market_projection:<br>
+:param&nbsp;MarketSort&nbsp;sort:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_market_profit_and_loss"><strong>list_market_profit_and_loss</strong></a>(self, market_ids, include_settled_bets<font color="#909090">=False</font>, include_bsp_bets<font color="#909090">=None</font>, net_of_commission<font color="#909090">=None</font>)</dt><dd><tt>Retrieve&nbsp;profit&nbsp;and&nbsp;loss&nbsp;for&nbsp;a&nbsp;given&nbsp;list&nbsp;of&nbsp;markets.<br>
+&nbsp;<br>
+:param&nbsp;list&nbsp;market_ids:&nbsp;List&nbsp;of&nbsp;markets&nbsp;to&nbsp;calculate&nbsp;profit&nbsp;and&nbsp;loss<br>
+:param&nbsp;bool&nbsp;include_settled_bets:&nbsp;Option&nbsp;to&nbsp;include&nbsp;settled&nbsp;bets<br>
+:param&nbsp;bool&nbsp;include_bsp_bets:&nbsp;Option&nbsp;to&nbsp;include&nbsp;BSP&nbsp;bets<br>
+:param&nbsp;bool&nbsp;net_of_commission:&nbsp;Option&nbsp;to&nbsp;return&nbsp;profit&nbsp;and&nbsp;loss&nbsp;net&nbsp;of<br>
+&nbsp;&nbsp;&nbsp;&nbsp;users&nbsp;current&nbsp;commission&nbsp;rate&nbsp;for&nbsp;this&nbsp;market&nbsp;including&nbsp;any&nbsp;special<br>
+&nbsp;&nbsp;&nbsp;&nbsp;tariffs</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_market_types"><strong>list_market_types</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_time_ranges"><strong>list_time_ranges</strong></a>(self, filter, granularity)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;TimeGranularity&nbsp;granularity:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-list_venues"><strong>list_venues</strong></a>(self, filter, locale<font color="#909090">=None</font>)</dt><dd><tt>:param&nbsp;MarketFilter&nbsp;filter:<br>
+:param&nbsp;str&nbsp;locale:</tt></dd></dl>
+
+<dl><dt><a name="Betfair-login"><strong>login</strong></a>(self, username, password)</dt><dd><tt>Log&nbsp;in&nbsp;to&nbsp;<a href="#Betfair">Betfair</a>.&nbsp;Sets&nbsp;`session_token`&nbsp;if&nbsp;successful.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;username:&nbsp;Username<br>
+:param&nbsp;str&nbsp;password:&nbsp;Password<br>
+:raises:&nbsp;BetfairLoginError</tt></dd></dl>
+
+<dl><dt><a name="Betfair-logout"><strong>logout</strong></a>(self)</dt><dd><tt>Log&nbsp;out&nbsp;and&nbsp;clear&nbsp;`session_token`.<br>
+&nbsp;<br>
+:raises:&nbsp;BetfairAuthError</tt></dd></dl>
+
+<dl><dt><a name="Betfair-make_api_request"><strong>make_api_request</strong></a>(self, method, params, codes<font color="#909090">=None</font>, model<font color="#909090">=None</font>)</dt></dl>
+
+<dl><dt><a name="Betfair-make_auth_request"><strong>make_auth_request</strong></a>(self, method)</dt></dl>
+
+<dl><dt><a name="Betfair-place_orders"><strong>place_orders</strong></a>(self, market_id, instructions, customer_ref<font color="#909090">=None</font>)</dt><dd><tt>Place&nbsp;new&nbsp;orders&nbsp;into&nbsp;market.&nbsp;This&nbsp;operation&nbsp;is&nbsp;atomic&nbsp;in&nbsp;that&nbsp;all<br>
+orders&nbsp;will&nbsp;be&nbsp;placed&nbsp;or&nbsp;none&nbsp;will&nbsp;be&nbsp;placed.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;market_id:&nbsp;The&nbsp;market&nbsp;id&nbsp;these&nbsp;orders&nbsp;are&nbsp;to&nbsp;be&nbsp;placed&nbsp;on<br>
+:param&nbsp;list&nbsp;instructions:&nbsp;List&nbsp;of&nbsp;`PlaceInstruction`&nbsp;objects<br>
+:param&nbsp;str&nbsp;customer_ref:&nbsp;Optional&nbsp;order&nbsp;identifier&nbsp;string</tt></dd></dl>
+
+<dl><dt><a name="Betfair-replace_orders"><strong>replace_orders</strong></a>(self, market_id, instructions, customer_ref<font color="#909090">=None</font>)</dt><dd><tt>This&nbsp;operation&nbsp;is&nbsp;logically&nbsp;a&nbsp;bulk&nbsp;cancel&nbsp;followed&nbsp;by&nbsp;a&nbsp;bulk&nbsp;place.<br>
+The&nbsp;cancel&nbsp;is&nbsp;completed&nbsp;first&nbsp;then&nbsp;the&nbsp;new&nbsp;orders&nbsp;are&nbsp;placed.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;market_id:&nbsp;The&nbsp;market&nbsp;id&nbsp;these&nbsp;orders&nbsp;are&nbsp;to&nbsp;be&nbsp;placed&nbsp;on<br>
+:param&nbsp;list&nbsp;instructions:&nbsp;List&nbsp;of&nbsp;`ReplaceInstruction`&nbsp;objects<br>
+:param&nbsp;str&nbsp;customer_ref:&nbsp;Optional&nbsp;order&nbsp;identifier&nbsp;string</tt></dd></dl>
+
+<dl><dt><a name="Betfair-update_orders"><strong>update_orders</strong></a>(self, market_id, instructions, customer_ref<font color="#909090">=None</font>)</dt><dd><tt>Update&nbsp;non-exposure&nbsp;changing&nbsp;fields.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;market_id:&nbsp;The&nbsp;market&nbsp;id&nbsp;these&nbsp;orders&nbsp;are&nbsp;to&nbsp;be&nbsp;placed&nbsp;on<br>
+:param&nbsp;list&nbsp;instructions:&nbsp;List&nbsp;of&nbsp;`UpdateInstruction`&nbsp;objects<br>
+:param&nbsp;str&nbsp;customer_ref:&nbsp;Optional&nbsp;order&nbsp;identifier&nbsp;string</tt></dd></dl>
+
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>headers</strong></dt>
+</dl>
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>API_URL</strong> = 'https://api.betfair.com/exchange/betting/json-rpc/v1/'<br>
+<strong>IDENTITY_URL</strong> = 'https://identitysso.betfair.com/api/'</td></tr></table>
+</body></html>

--- a/docs/betfair.constants.html
+++ b/docs/betfair.constants.html
@@ -1,0 +1,52 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.constants</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.constants</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/constants.py">/home/james/projects/betfair.py/betfair/constants.py</a></font></td></tr></table>
+    <p><tt>BetFair&nbsp;betting&nbsp;enums.&nbsp;See<br>
+https://api.developer.betfair.com/services/webapps/docs/display/1smk3cen4v3lu3yomq5qye0ni/Betting+Enums</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="enum.html#Enum">enum.Enum</a>(<a href="__builtin__.html#object">__builtin__.object</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.constants.html#BetStatus">BetStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#ExecutionReportErrorCode">ExecutionReportErrorCode</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#ExecutionReportStatus">ExecutionReportStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#GroupBy">GroupBy</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#InstructionReportErrorCode">InstructionReportErrorCode</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#InstructionReportStatus">InstructionReportStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#MarketBettingType">MarketBettingType</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#MarketProjection">MarketProjection</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#MarketSort">MarketSort</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#MarketStatus">MarketStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#MatchProjection">MatchProjection</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#OrderBy">OrderBy</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#OrderProjection">OrderProjection</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#OrderStatus">OrderStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#OrderType">OrderType</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#PersistenceType">PersistenceType</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#PriceData">PriceData</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#RollupModel">RollupModel</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#RunnerStatus">RunnerStatus</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#Side">Side</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#SortDir">SortDir</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.constants.html#TimeGranularity">TimeGranularity</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <strong>BetStatus</strong> = &lt;enum 'BetStatus'&gt; <strong>ExecutionReportErrorCode</strong> = &lt;enum 'ExecutionReportErrorCode'&gt; <strong>ExecutionReportStatus</strong> = &lt;enum 'ExecutionReportStatus'&gt; <strong>GroupBy</strong> = &lt;enum 'GroupBy'&gt; <strong>InstructionReportErrorCode</strong> = &lt;enum 'InstructionReportErrorCode'&gt; <strong>InstructionReportStatus</strong> = &lt;enum 'InstructionReportStatus'&gt; <strong>MarketBettingType</strong> = &lt;enum 'MarketBettingType'&gt; <strong>MarketProjection</strong> = &lt;enum 'MarketProjection'&gt; <strong>MarketSort</strong> = &lt;enum 'MarketSort'&gt; <strong>MarketStatus</strong> = &lt;enum 'MarketStatus'&gt; <strong>MatchProjection</strong> = &lt;enum 'MatchProjection'&gt; <strong>OrderBy</strong> = &lt;enum 'OrderBy'&gt; <strong>OrderProjection</strong> = &lt;enum 'OrderProjection'&gt; <strong>OrderStatus</strong> = &lt;enum 'OrderStatus'&gt; <strong>OrderType</strong> = &lt;enum 'OrderType'&gt; <strong>PersistenceType</strong> = &lt;enum 'PersistenceType'&gt; <strong>PriceData</strong> = &lt;enum 'PriceData'&gt; <strong>RollupModel</strong> = &lt;enum 'RollupModel'&gt; <strong>RunnerStatus</strong> = &lt;enum 'RunnerStatus'&gt; <strong>Side</strong> = &lt;enum 'Side'&gt; <strong>SortDir</strong> = &lt;enum 'SortDir'&gt; <strong>TimeGranularity</strong> = &lt;enum 'TimeGranularity'&gt;</td></tr></table>
+</body></html>

--- a/docs/betfair.datatype.html
+++ b/docs/betfair.datatype.html
@@ -1,0 +1,126 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.datatype</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.datatype</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/datatype.py">/home/james/projects/betfair.py/betfair/datatype.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="datetime.html">datetime</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>(<a href="__builtin__.html#object">__builtin__.object</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.datatype.html#EnumType">EnumType</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.datatype.html#ModelType">ModelType</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="EnumType">class <strong>EnumType</strong></a>(<a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.datatype.html#EnumType">EnumType</a></dd>
+<dd><a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="EnumType-serialize"><strong>serialize</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="EnumType-unserialize"><strong>unserialize</strong></a>(self, value)</dt></dl>
+
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__slotnames__</strong> = []</dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>:<br>
+<dl><dt><a name="EnumType-__init__"><strong>__init__</strong></a>(self, type, preprocessor<font color="#909090">=None</font>)</dt></dl>
+
+<dl><dt><a name="EnumType-preprocess"><strong>preprocess</strong></a>(self, value)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ModelType">class <strong>ModelType</strong></a>(<a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.datatype.html#ModelType">ModelType</a></dd>
+<dd><a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="ModelType-serialize"><strong>serialize</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="ModelType-unserialize"><strong>unserialize</strong></a>(self, value)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>:<br>
+<dl><dt><a name="ModelType-__init__"><strong>__init__</strong></a>(self, type, preprocessor<font color="#909090">=None</font>)</dt></dl>
+
+<dl><dt><a name="ModelType-preprocess"><strong>preprocess</strong></a>(self, value)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="betfair.meta.datatype.html#DataType">betfair.meta.datatype.DataType</a>:<br>
+<dl><dt><strong>__slotnames__</strong> = []</dl>
+
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-preprocess_date"><strong>preprocess_date</strong></a>(date)</dt></dl>
+</td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>datetime_type</strong> = &lt;betfair.meta.datatype.DataType object&gt;</td></tr></table>
+</body></html>

--- a/docs/betfair.exceptions.html
+++ b/docs/betfair.exceptions.html
@@ -1,0 +1,272 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.exceptions</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.exceptions</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/exceptions.py">/home/james/projects/betfair.py/betfair/exceptions.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="exceptions.html#Exception">exceptions.Exception</a>(<a href="exceptions.html#BaseException">exceptions.BaseException</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.exceptions.html#BetfairError">BetfairError</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.exceptions.html#BetfairAPIError">BetfairAPIError</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.exceptions.html#BetfairAuthError">BetfairAuthError</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.exceptions.html#BetfairLoginError">BetfairLoginError</a>
+</font></dt></dl>
+</dd>
+</dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BetfairAPIError">class <strong>BetfairAPIError</strong></a>(<a href="betfair.exceptions.html#BetfairError">BetfairError</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.exceptions.html#BetfairAPIError">BetfairAPIError</a></dd>
+<dd><a href="betfair.exceptions.html#BetfairError">BetfairError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="BetfairAPIError-__init__"><strong>__init__</strong></a>(self, response, data)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.exceptions.html#BetfairError">BetfairError</a>:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#BetfairAPIError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="BetfairAPIError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairAPIError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairAPIError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAPIError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairAPIError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BetfairAuthError">class <strong>BetfairAuthError</strong></a>(<a href="betfair.exceptions.html#BetfairError">BetfairError</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.exceptions.html#BetfairAuthError">BetfairAuthError</a></dd>
+<dd><a href="betfair.exceptions.html#BetfairError">BetfairError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="BetfairAuthError-__init__"><strong>__init__</strong></a>(self, response, data)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.exceptions.html#BetfairError">BetfairError</a>:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#BetfairAuthError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="BetfairAuthError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairAuthError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairAuthError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairAuthError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairAuthError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BetfairError">class <strong>BetfairError</strong></a>(<a href="exceptions.html#Exception">exceptions.Exception</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.exceptions.html#BetfairError">BetfairError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Methods inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><a name="BetfairError-__init__"><strong>__init__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__init__">__init__</a>(...)&nbsp;initializes&nbsp;x;&nbsp;see&nbsp;help(type(x))&nbsp;for&nbsp;signature</tt></dd></dl>
+
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#BetfairError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="BetfairError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BetfairLoginError">class <strong>BetfairLoginError</strong></a>(<a href="betfair.exceptions.html#BetfairError">BetfairError</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.exceptions.html#BetfairLoginError">BetfairLoginError</a></dd>
+<dd><a href="betfair.exceptions.html#BetfairError">BetfairError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="BetfairLoginError-__init__"><strong>__init__</strong></a>(self, response, data)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.exceptions.html#BetfairError">BetfairError</a>:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#BetfairLoginError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="BetfairLoginError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairLoginError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="BetfairLoginError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#BetfairLoginError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="BetfairLoginError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.html
+++ b/docs/betfair.html
@@ -1,0 +1,37 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: package betfair</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>betfair</strong></big></big> (version 0.1.3)</font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/__init__.py">/home/james/projects/betfair.py/betfair/__init__.py</a></font></td></tr></table>
+    <p></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Package Contents</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.betfair.html">betfair</a><br>
+<a href="betfair.constants.html">constants</a><br>
+</td><td width="25%" valign=top><a href="betfair.datatype.html">datatype</a><br>
+<a href="betfair.exceptions.html">exceptions</a><br>
+</td><td width="25%" valign=top><a href="betfair.meta.html"><strong>meta</strong>&nbsp;(package)</a><br>
+<a href="betfair.model.html">model</a><br>
+</td><td width="25%" valign=top><a href="betfair.models.html">models</a><br>
+<a href="betfair.utils.html">utils</a><br>
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>__version__</strong> = '0.1.3'</td></tr></table>
+</body></html>

--- a/docs/betfair.meta.datatype.html
+++ b/docs/betfair.meta.datatype.html
@@ -1,0 +1,58 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.meta.datatype</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.<a href="betfair.meta.html"><font color="#ffffff">meta</font></a>.datatype</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/meta/datatype.py">/home/james/projects/betfair.py/betfair/meta/datatype.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="__builtin__.html#object">__builtin__.object</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.datatype.html#DataType">DataType</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="DataType">class <strong>DataType</strong></a>(<a href="__builtin__.html#object">__builtin__.object</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%">Methods defined here:<br>
+<dl><dt><a name="DataType-__init__"><strong>__init__</strong></a>(self, type, preprocessor<font color="#909090">=None</font>)</dt></dl>
+
+<dl><dt><a name="DataType-preprocess"><strong>preprocess</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="DataType-serialize"><strong>serialize</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="DataType-unserialize"><strong>unserialize</strong></a>(self, value)</dt></dl>
+
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__slotnames__</strong> = []</dl>
+
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.meta.exceptions.html
+++ b/docs/betfair.meta.exceptions.html
@@ -1,0 +1,154 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.meta.exceptions</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.<a href="betfair.meta.html"><font color="#ffffff">meta</font></a>.exceptions</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/meta/exceptions.py">/home/james/projects/betfair.py/betfair/meta/exceptions.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="exceptions.html#Exception">exceptions.Exception</a>(<a href="exceptions.html#BaseException">exceptions.BaseException</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.exceptions.html#ModelError">ModelError</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.exceptions.html#MissingValueError">MissingValueError</a>(<a href="betfair.meta.exceptions.html#ModelError">ModelError</a>, <a href="exceptions.html#ValueError">exceptions.ValueError</a>)
+</font></dt></dl>
+</dd>
+</dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MissingValueError">class <strong>MissingValueError</strong></a>(<a href="betfair.meta.exceptions.html#ModelError">ModelError</a>, <a href="exceptions.html#ValueError">exceptions.ValueError</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.meta.exceptions.html#MissingValueError">MissingValueError</a></dd>
+<dd><a href="betfair.meta.exceptions.html#ModelError">ModelError</a></dd>
+<dd><a href="exceptions.html#ValueError">exceptions.ValueError</a></dd>
+<dd><a href="exceptions.html#StandardError">exceptions.StandardError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors inherited from <a href="betfair.meta.exceptions.html#ModelError">ModelError</a>:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Methods inherited from <a href="exceptions.html#ValueError">exceptions.ValueError</a>:<br>
+<dl><dt><a name="MissingValueError-__init__"><strong>__init__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__init__">__init__</a>(...)&nbsp;initializes&nbsp;x;&nbsp;see&nbsp;help(type(x))&nbsp;for&nbsp;signature</tt></dd></dl>
+
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#ValueError">exceptions.ValueError</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#MissingValueError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="MissingValueError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="MissingValueError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="MissingValueError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#MissingValueError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="MissingValueError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ModelError">class <strong>ModelError</strong></a>(<a href="exceptions.html#Exception">exceptions.Exception</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.meta.exceptions.html#ModelError">ModelError</a></dd>
+<dd><a href="exceptions.html#Exception">exceptions.Exception</a></dd>
+<dd><a href="exceptions.html#BaseException">exceptions.BaseException</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Methods inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><a name="ModelError-__init__"><strong>__init__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__init__">__init__</a>(...)&nbsp;initializes&nbsp;x;&nbsp;see&nbsp;help(type(x))&nbsp;for&nbsp;signature</tt></dd></dl>
+
+<hr>
+Data and other attributes inherited from <a href="exceptions.html#Exception">exceptions.Exception</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#ModelError-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;object&nbsp;with&nbsp;type&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+<hr>
+Methods inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><a name="ModelError-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__getitem__"><strong>__getitem__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__getitem__">__getitem__</a>(y)&nbsp;&lt;==&gt;&nbsp;x[y]</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__getslice__"><strong>__getslice__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__getslice__">__getslice__</a>(i,&nbsp;j)&nbsp;&lt;==&gt;&nbsp;x[i:j]<br>
+&nbsp;<br>
+Use&nbsp;of&nbsp;negative&nbsp;indices&nbsp;is&nbsp;not&nbsp;supported.</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__reduce__"><strong>__reduce__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="ModelError-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__setstate__"><strong>__setstate__</strong></a>(...)</dt></dl>
+
+<dl><dt><a name="ModelError-__str__"><strong>__str__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelError-__str__">__str__</a>()&nbsp;&lt;==&gt;&nbsp;str(x)</tt></dd></dl>
+
+<dl><dt><a name="ModelError-__unicode__"><strong>__unicode__</strong></a>(...)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="exceptions.html#BaseException">exceptions.BaseException</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>args</strong></dt>
+</dl>
+<dl><dt><strong>message</strong></dt>
+</dl>
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.meta.field.html
+++ b/docs/betfair.meta.field.html
@@ -1,0 +1,212 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.meta.field</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.<a href="betfair.meta.html"><font color="#ffffff">meta</font></a>.field</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/meta/field.py">/home/james/projects/betfair.py/betfair/meta/field.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="collections.html">collections</a><br>
+</td><td width="25%" valign=top><a href="betfair.meta.exceptions.html">betfair.meta.exceptions</a><br>
+</td><td width="25%" valign=top><a href="weakref.html">weakref</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="__builtin__.html#object">__builtin__.object</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.field.html#Field">Field</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.field.html#ListField">ListField</a>
+</font></dt></dl>
+</dd>
+</dl>
+</dd>
+<dt><font face="helvetica, arial"><a href="_abcoll.html#MutableSequence">_abcoll.MutableSequence</a>(<a href="_abcoll.html#Sequence">_abcoll.Sequence</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.field.html#ListContainer">ListContainer</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Field">class <strong>Field</strong></a>(<a href="__builtin__.html#object">__builtin__.object</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%">Methods defined here:<br>
+<dl><dt><a name="Field-__get__"><strong>__get__</strong></a>(self, instance, owner)</dt></dl>
+
+<dl><dt><a name="Field-__init__"><strong>__init__</strong></a>(self, data_type, required<font color="#909090">=False</font>)</dt></dl>
+
+<dl><dt><a name="Field-__set__"><strong>__set__</strong></a>(self, instance, value, safe<font color="#909090">=False</font>)</dt></dl>
+
+<dl><dt><a name="Field-is_null"><strong>is_null</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="Field-missing_value"><strong>missing_value</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Field-serialize"><strong>serialize</strong></a>(self, instance)</dt></dl>
+
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__slotnames__</strong> = []</dl>
+
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ListContainer">class <strong>ListContainer</strong></a>(<a href="_abcoll.html#MutableSequence">_abcoll.MutableSequence</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.meta.field.html#ListContainer">ListContainer</a></dd>
+<dd><a href="_abcoll.html#MutableSequence">_abcoll.MutableSequence</a></dd>
+<dd><a href="_abcoll.html#Sequence">_abcoll.Sequence</a></dd>
+<dd><a href="_abcoll.html#Sized">_abcoll.Sized</a></dd>
+<dd><a href="_abcoll.html#Iterable">_abcoll.Iterable</a></dd>
+<dd><a href="_abcoll.html#Container">_abcoll.Container</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="ListContainer-__delitem__"><strong>__delitem__</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ListContainer-__getitem__"><strong>__getitem__</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ListContainer-__init__"><strong>__init__</strong></a>(self, data_type, value<font color="#909090">=None</font>)</dt></dl>
+
+<dl><dt><a name="ListContainer-__len__"><strong>__len__</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ListContainer-__setitem__"><strong>__setitem__</strong></a>(self, key, value)</dt></dl>
+
+<dl><dt><a name="ListContainer-insert"><strong>insert</strong></a>(self, key, value)</dt></dl>
+
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>__abstractmethods__</strong> = frozenset([])</dl>
+
+<hr>
+Methods inherited from <a href="_abcoll.html#MutableSequence">_abcoll.MutableSequence</a>:<br>
+<dl><dt><a name="ListContainer-__iadd__"><strong>__iadd__</strong></a>(self, values)</dt></dl>
+
+<dl><dt><a name="ListContainer-append"><strong>append</strong></a>(self, value)</dt><dd><tt>S.<a href="#ListContainer-append">append</a>(<a href="__builtin__.html#object">object</a>)&nbsp;--&nbsp;append&nbsp;<a href="__builtin__.html#object">object</a>&nbsp;to&nbsp;the&nbsp;end&nbsp;of&nbsp;the&nbsp;sequence</tt></dd></dl>
+
+<dl><dt><a name="ListContainer-extend"><strong>extend</strong></a>(self, values)</dt><dd><tt>S.<a href="#ListContainer-extend">extend</a>(iterable)&nbsp;--&nbsp;extend&nbsp;sequence&nbsp;by&nbsp;appending&nbsp;elements&nbsp;from&nbsp;the&nbsp;iterable</tt></dd></dl>
+
+<dl><dt><a name="ListContainer-pop"><strong>pop</strong></a>(self, index<font color="#909090">=-1</font>)</dt><dd><tt>S.<a href="#ListContainer-pop">pop</a>([index])&nbsp;-&gt;&nbsp;item&nbsp;--&nbsp;remove&nbsp;and&nbsp;return&nbsp;item&nbsp;at&nbsp;index&nbsp;(default&nbsp;last).<br>
+Raise&nbsp;IndexError&nbsp;if&nbsp;list&nbsp;is&nbsp;empty&nbsp;or&nbsp;index&nbsp;is&nbsp;out&nbsp;of&nbsp;range.</tt></dd></dl>
+
+<dl><dt><a name="ListContainer-remove"><strong>remove</strong></a>(self, value)</dt><dd><tt>S.<a href="#ListContainer-remove">remove</a>(value)&nbsp;--&nbsp;remove&nbsp;first&nbsp;occurrence&nbsp;of&nbsp;value.<br>
+Raise&nbsp;ValueError&nbsp;if&nbsp;the&nbsp;value&nbsp;is&nbsp;not&nbsp;present.</tt></dd></dl>
+
+<dl><dt><a name="ListContainer-reverse"><strong>reverse</strong></a>(self)</dt><dd><tt>S.<a href="#ListContainer-reverse">reverse</a>()&nbsp;--&nbsp;reverse&nbsp;*IN&nbsp;PLACE*</tt></dd></dl>
+
+<hr>
+Methods inherited from <a href="_abcoll.html#Sequence">_abcoll.Sequence</a>:<br>
+<dl><dt><a name="ListContainer-__contains__"><strong>__contains__</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="ListContainer-__iter__"><strong>__iter__</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ListContainer-__reversed__"><strong>__reversed__</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ListContainer-count"><strong>count</strong></a>(self, value)</dt><dd><tt>S.<a href="#ListContainer-count">count</a>(value)&nbsp;-&gt;&nbsp;integer&nbsp;--&nbsp;return&nbsp;number&nbsp;of&nbsp;occurrences&nbsp;of&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="ListContainer-index"><strong>index</strong></a>(self, value)</dt><dd><tt>S.<a href="#ListContainer-index">index</a>(value)&nbsp;-&gt;&nbsp;integer&nbsp;--&nbsp;return&nbsp;first&nbsp;index&nbsp;of&nbsp;value.<br>
+Raises&nbsp;ValueError&nbsp;if&nbsp;the&nbsp;value&nbsp;is&nbsp;not&nbsp;present.</tt></dd></dl>
+
+<hr>
+Class methods inherited from <a href="_abcoll.html#Sized">_abcoll.Sized</a>:<br>
+<dl><dt><a name="ListContainer-__subclasshook__"><strong>__subclasshook__</strong></a>(cls, C)<font color="#909090"><font face="helvetica, arial"> from <a href="abc.html#ABCMeta">abc.ABCMeta</a></font></font></dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="_abcoll.html#Sized">_abcoll.Sized</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="_abcoll.html#Sized">_abcoll.Sized</a>:<br>
+<dl><dt><strong>__metaclass__</strong> = &lt;class 'abc.ABCMeta'&gt;<dd><tt>Metaclass&nbsp;for&nbsp;defining&nbsp;Abstract&nbsp;Base&nbsp;Classes&nbsp;(ABCs).<br>
+&nbsp;<br>
+Use&nbsp;this&nbsp;metaclass&nbsp;to&nbsp;create&nbsp;an&nbsp;ABC.&nbsp;&nbsp;An&nbsp;ABC&nbsp;can&nbsp;be&nbsp;subclassed<br>
+directly,&nbsp;and&nbsp;then&nbsp;acts&nbsp;as&nbsp;a&nbsp;mix-in&nbsp;class.&nbsp;&nbsp;You&nbsp;can&nbsp;also&nbsp;register<br>
+unrelated&nbsp;concrete&nbsp;classes&nbsp;(even&nbsp;built-in&nbsp;classes)&nbsp;and&nbsp;unrelated<br>
+ABCs&nbsp;as&nbsp;'virtual&nbsp;subclasses'&nbsp;--&nbsp;these&nbsp;and&nbsp;their&nbsp;descendants&nbsp;will<br>
+be&nbsp;considered&nbsp;subclasses&nbsp;of&nbsp;the&nbsp;registering&nbsp;ABC&nbsp;by&nbsp;the&nbsp;built-in<br>
+issubclass()&nbsp;function,&nbsp;but&nbsp;the&nbsp;registering&nbsp;ABC&nbsp;won't&nbsp;show&nbsp;up&nbsp;in<br>
+their&nbsp;MRO&nbsp;(Method&nbsp;Resolution&nbsp;Order)&nbsp;nor&nbsp;will&nbsp;method<br>
+implementations&nbsp;defined&nbsp;by&nbsp;the&nbsp;registering&nbsp;ABC&nbsp;be&nbsp;callable&nbsp;(not<br>
+even&nbsp;via&nbsp;super()).</tt></dl>
+
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ListField">class <strong>ListField</strong></a>(<a href="betfair.meta.field.html#Field">Field</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.meta.field.html#ListField">ListField</a></dd>
+<dd><a href="betfair.meta.field.html#Field">Field</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="ListField-__set__"><strong>__set__</strong></a>(self, instance, value, safe<font color="#909090">=False</font>)</dt></dl>
+
+<dl><dt><a name="ListField-is_null"><strong>is_null</strong></a>(self, value)</dt></dl>
+
+<dl><dt><a name="ListField-missing_value"><strong>missing_value</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ListField-serialize"><strong>serialize</strong></a>(self, instance)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.field.html#Field">Field</a>:<br>
+<dl><dt><a name="ListField-__get__"><strong>__get__</strong></a>(self, instance, owner)</dt></dl>
+
+<dl><dt><a name="ListField-__init__"><strong>__init__</strong></a>(self, data_type, required<font color="#909090">=False</font>)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.field.html#Field">Field</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="betfair.meta.field.html#Field">Field</a>:<br>
+<dl><dt><strong>__slotnames__</strong> = []</dl>
+
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.meta.html
+++ b/docs/betfair.meta.html
@@ -1,0 +1,26 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: package betfair.meta</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.meta</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/meta/__init__.py">/home/james/projects/betfair.py/betfair/meta/__init__.py</a></font></td></tr></table>
+    <p></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Package Contents</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.meta.datatype.html">datatype</a><br>
+</td><td width="25%" valign=top><a href="betfair.meta.exceptions.html">exceptions</a><br>
+</td><td width="25%" valign=top><a href="betfair.meta.field.html">field</a><br>
+</td><td width="25%" valign=top><a href="betfair.meta.model.html">model</a><br>
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.meta.model.html
+++ b/docs/betfair.meta.model.html
@@ -1,0 +1,174 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.meta.model</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.<a href="betfair.meta.html"><font color="#ffffff">meta</font></a>.model</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/meta/model.py">/home/james/projects/betfair.py/betfair/meta/model.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="copy.html">copy</a><br>
+</td><td width="25%" valign=top><a href="six.html">six</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="__builtin__.html#object">__builtin__.object</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.model.html#Model">Model</a>
+</font></dt></dl>
+</dd>
+<dt><font face="helvetica, arial"><a href="__builtin__.html#type">__builtin__.type</a>(<a href="__builtin__.html#object">__builtin__.object</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.model.html#ModelMeta">ModelMeta</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Model">class <strong>Model</strong></a>(<a href="__builtin__.html#object">__builtin__.object</a>)</font></td></tr>
+    
+<tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
+<td colspan=2><tt><a href="#Model">Model</a>&nbsp;base&nbsp;class.&nbsp;Subclasses&nbsp;should&nbsp;define&nbsp;`Field`&nbsp;descriptors,&nbsp;which<br>
+are&nbsp;collected&nbsp;in&nbsp;`_fields`.&nbsp;Note:&nbsp;to&nbsp;avoid&nbsp;circular&nbsp;definitions,&nbsp;the<br>
+`<a href="#ModelMeta">ModelMeta</a>`&nbsp;metaclass&nbsp;is&nbsp;not&nbsp;applied&nbsp;until&nbsp;after&nbsp;`<a href="#Model">Model</a>`&nbsp;has&nbsp;been&nbsp;defined.<br>&nbsp;</tt></td></tr>
+<tr><td>&nbsp;</td>
+<td width="100%">Methods defined here:<br>
+<dl><dt><a name="Model-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Model-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Model-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Model-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Model-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<dl><dt><a name="Model-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {}</dl>
+
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ModelMeta">class <strong>ModelMeta</strong></a>(<a href="__builtin__.html#type">__builtin__.type</a>)</font></td></tr>
+    
+<tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
+<td colspan=2><tt><a href="#Model">Model</a>&nbsp;metaclass.&nbsp;Collects&nbsp;field&nbsp;descriptors&nbsp;and&nbsp;inherits&nbsp;fields&nbsp;from<br>
+parent.<br>&nbsp;</tt></td></tr>
+<tr><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.meta.model.html#ModelMeta">ModelMeta</a></dd>
+<dd><a href="__builtin__.html#type">__builtin__.type</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="ModelMeta-__init__"><strong>__init__</strong></a>(cls, name, bases, dct)</dt></dl>
+
+<hr>
+Methods inherited from <a href="__builtin__.html#type">__builtin__.type</a>:<br>
+<dl><dt><a name="ModelMeta-__call__"><strong>__call__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__call__">__call__</a>(...)&nbsp;&lt;==&gt;&nbsp;x(...)</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__delattr__"><strong>__delattr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__delattr__">__delattr__</a>('name')&nbsp;&lt;==&gt;&nbsp;del&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__eq__"><strong>__eq__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__eq__">__eq__</a>(y)&nbsp;&lt;==&gt;&nbsp;x==y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__ge__"><strong>__ge__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__ge__">__ge__</a>(y)&nbsp;&lt;==&gt;&nbsp;x&gt;=y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__getattribute__"><strong>__getattribute__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__getattribute__">__getattribute__</a>('name')&nbsp;&lt;==&gt;&nbsp;x.name</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__gt__"><strong>__gt__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__gt__">__gt__</a>(y)&nbsp;&lt;==&gt;&nbsp;x&gt;y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__hash__"><strong>__hash__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__hash__">__hash__</a>()&nbsp;&lt;==&gt;&nbsp;hash(x)</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__instancecheck__"><strong>__instancecheck__</strong></a>(...)</dt><dd><tt><a href="#ModelMeta-__instancecheck__">__instancecheck__</a>()&nbsp;-&gt;&nbsp;bool<br>
+check&nbsp;if&nbsp;an&nbsp;<a href="__builtin__.html#object">object</a>&nbsp;is&nbsp;an&nbsp;instance</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__le__"><strong>__le__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__le__">__le__</a>(y)&nbsp;&lt;==&gt;&nbsp;x&lt;=y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__lt__"><strong>__lt__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__lt__">__lt__</a>(y)&nbsp;&lt;==&gt;&nbsp;x&lt;y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__ne__"><strong>__ne__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__ne__">__ne__</a>(y)&nbsp;&lt;==&gt;&nbsp;x!=y</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__repr__"><strong>__repr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__repr__">__repr__</a>()&nbsp;&lt;==&gt;&nbsp;repr(x)</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__setattr__"><strong>__setattr__</strong></a>(...)</dt><dd><tt>x.<a href="#ModelMeta-__setattr__">__setattr__</a>('name',&nbsp;value)&nbsp;&lt;==&gt;&nbsp;x.name&nbsp;=&nbsp;value</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__subclasscheck__"><strong>__subclasscheck__</strong></a>(...)</dt><dd><tt><a href="#ModelMeta-__subclasscheck__">__subclasscheck__</a>()&nbsp;-&gt;&nbsp;bool<br>
+check&nbsp;if&nbsp;a&nbsp;class&nbsp;is&nbsp;a&nbsp;subclass</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-__subclasses__"><strong>__subclasses__</strong></a>(...)</dt><dd><tt><a href="#ModelMeta-__subclasses__">__subclasses__</a>()&nbsp;-&gt;&nbsp;list&nbsp;of&nbsp;immediate&nbsp;subclasses</tt></dd></dl>
+
+<dl><dt><a name="ModelMeta-mro"><strong>mro</strong></a>(...)</dt><dd><tt><a href="#ModelMeta-mro">mro</a>()&nbsp;-&gt;&nbsp;list<br>
+return&nbsp;a&nbsp;<a href="__builtin__.html#type">type</a>'s&nbsp;method&nbsp;resolution&nbsp;order</tt></dd></dl>
+
+<hr>
+Data descriptors inherited from <a href="__builtin__.html#type">__builtin__.type</a>:<br>
+<dl><dt><strong>__abstractmethods__</strong></dt>
+</dl>
+<dl><dt><strong>__base__</strong></dt>
+</dl>
+<dl><dt><strong>__bases__</strong></dt>
+</dl>
+<dl><dt><strong>__basicsize__</strong></dt>
+</dl>
+<dl><dt><strong>__dict__</strong></dt>
+</dl>
+<dl><dt><strong>__dictoffset__</strong></dt>
+</dl>
+<dl><dt><strong>__flags__</strong></dt>
+</dl>
+<dl><dt><strong>__itemsize__</strong></dt>
+</dl>
+<dl><dt><strong>__mro__</strong></dt>
+</dl>
+<dl><dt><strong>__weakrefoffset__</strong></dt>
+</dl>
+<hr>
+Data and other attributes inherited from <a href="__builtin__.html#type">__builtin__.type</a>:<br>
+<dl><dt><strong>__new__</strong> = &lt;built-in method __new__ of type object&gt;<dd><tt>T.<a href="#ModelMeta-__new__">__new__</a>(S,&nbsp;...)&nbsp;-&gt;&nbsp;a&nbsp;new&nbsp;<a href="__builtin__.html#object">object</a>&nbsp;with&nbsp;<a href="__builtin__.html#type">type</a>&nbsp;S,&nbsp;a&nbsp;subtype&nbsp;of&nbsp;T</tt></dl>
+
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-copy_fields"><strong>copy_fields</strong></a>(bases)</dt><dd><tt>Deep-copy&nbsp;and&nbsp;collect&nbsp;`Field`&nbsp;descriptors&nbsp;from&nbsp;base&nbsp;classes.<br>
+&nbsp;<br>
+:param&nbsp;list&nbsp;bases:&nbsp;Base&nbsp;classes<br>
+:returns:&nbsp;Dictionary&nbsp;of&nbsp;`Field`&nbsp;descriptors</tt></dd></dl>
+</td></tr></table>
+</body></html>

--- a/docs/betfair.model.html
+++ b/docs/betfair.model.html
@@ -1,0 +1,82 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.model</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.model</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/model.py">/home/james/projects/betfair.py/betfair/model.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="inflection.html">inflection</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>(<a href="__builtin__.html#object">__builtin__.object</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.model.html#BetfairModel">BetfairModel</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BetfairModel">class <strong>BetfairModel</strong></a>(<a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>)</font></td></tr>
+    
+<tr bgcolor="#ffc8d8"><td rowspan=2><tt>&nbsp;&nbsp;&nbsp;</tt></td>
+<td colspan=2><tt>Handle&nbsp;conversions&nbsp;between&nbsp;internal&nbsp;(underscore)&nbsp;and&nbsp;external&nbsp;(camel-<br>
+cased)&nbsp;key&nbsp;formatting;&nbsp;handle&nbsp;trailing&nbsp;underscores&nbsp;used&nbsp;to&nbsp;avoid&nbsp;conflicts<br>
+with&nbsp;build-ins&nbsp;(e.g.&nbsp;from_).<br>&nbsp;</tt></td></tr>
+<tr><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.model.html#BetfairModel">BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Methods defined here:<br>
+<dl><dt><a name="BetfairModel-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="BetfairModel-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="BetfairModel-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="BetfairModel-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BetfairModel-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BetfairModel-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table></td></tr></table>
+</body></html>

--- a/docs/betfair.models.html
+++ b/docs/betfair.models.html
@@ -1,0 +1,2707 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.models</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.models</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/models.py">/home/james/projects/betfair.py/betfair/models.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.constants.html">betfair.constants</a><br>
+</td><td width="25%" valign=top><a href="six.html">six</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ee77aa">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Classes</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#ee77aa"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl>
+<dt><font face="helvetica, arial"><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>(<a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>)
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.models.html#CancelExecutionReport">CancelExecutionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#PlaceExecutionReport">PlaceExecutionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ReplaceExecutionReport">ReplaceExecutionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#UpdateExecutionReport">UpdateExecutionReport</a>
+</font></dt></dl>
+</dd>
+<dt><font face="helvetica, arial"><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>
+</font></dt><dd>
+<dl>
+<dt><font face="helvetica, arial"><a href="betfair.models.html#CancelInstructionReport">CancelInstructionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#PlaceInstructionReport">PlaceInstructionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ReplaceInstructionReport">ReplaceInstructionReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#UpdateInstructionReport">UpdateInstructionReport</a>
+</font></dt></dl>
+</dd>
+<dt><font face="helvetica, arial"><a href="betfair.models.html#CancelInstruction">CancelInstruction</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ClearedOrderSummary">ClearedOrderSummary</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ClearedOrderSummaryReport">ClearedOrderSummaryReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#Competition">Competition</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#CompetitionResult">CompetitionResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#CountryCodeResult">CountryCodeResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#CurrentOrderSummary">CurrentOrderSummary</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#CurrentOrderSummaryReport">CurrentOrderSummaryReport</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#Event">Event</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#EventResult">EventResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#EventType">EventType</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#EventTypeResult">EventTypeResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ExBestOffersOverrides">ExBestOffersOverrides</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ExchangePrices">ExchangePrices</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ItemDescription">ItemDescription</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#LimitOnCloseOrder">LimitOnCloseOrder</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#LimitOrder">LimitOrder</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketBook">MarketBook</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketCatalogue">MarketCatalogue</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketDescription">MarketDescription</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketFilter">MarketFilter</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketOnCloseOrder">MarketOnCloseOrder</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketProfitAndLoss">MarketProfitAndLoss</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#MarketTypeResult">MarketTypeResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#Match">Match</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#Order">Order</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#PlaceInstruction">PlaceInstruction</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#PriceProjection">PriceProjection</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#PriceSize">PriceSize</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#ReplaceInstruction">ReplaceInstruction</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#Runner">Runner</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#RunnerCatalog">RunnerCatalog</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#RunnerProfitAndLoss">RunnerProfitAndLoss</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#StartingPrices">StartingPrices</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#TimeRange">TimeRange</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#TimeRangeResult">TimeRangeResult</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#UpdateInstruction">UpdateInstruction</a>
+</font></dt><dt><font face="helvetica, arial"><a href="betfair.models.html#VenueResult">VenueResult</a>
+</font></dt></dl>
+</dd>
+</dl>
+ <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BaseExecutionReport">class <strong>BaseExecutionReport</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>customer_ref</strong></dt>
+</dl>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'customer_ref': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="BaseExecutionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="BaseExecutionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="BaseExecutionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="BaseExecutionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BaseExecutionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BaseExecutionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="BaseInstructionReport">class <strong>BaseInstructionReport</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'error_code': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="BaseInstructionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="BaseInstructionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="BaseInstructionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="BaseInstructionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BaseInstructionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="BaseInstructionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CancelExecutionReport">class <strong>CancelExecutionReport</strong></a>(<a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CancelExecutionReport">CancelExecutionReport</a></dd>
+<dd><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>instruction_reports</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'customer_ref': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction_reports': &lt;betfair.meta.field.ListField object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>:<br>
+<dl><dt><strong>customer_ref</strong></dt>
+</dl>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CancelExecutionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CancelExecutionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CancelExecutionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CancelExecutionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelExecutionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelExecutionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CancelInstruction">class <strong>CancelInstruction</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CancelInstruction">CancelInstruction</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>size_reduction</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_id': &lt;betfair.meta.field.Field object&gt;, 'size_reduction': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CancelInstruction-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CancelInstruction-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CancelInstruction-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CancelInstruction-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelInstruction-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelInstruction-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CancelInstructionReport">class <strong>CancelInstructionReport</strong></a>(<a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CancelInstructionReport">CancelInstructionReport</a></dd>
+<dd><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>cancelled_date</strong></dt>
+</dl>
+<dl><dt><strong>instruction</strong></dt>
+</dl>
+<dl><dt><strong>size_cancelled</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'cancelled_date': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction': &lt;betfair.meta.field.Field object&gt;, 'size_cancelled': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>:<br>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CancelInstructionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CancelInstructionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CancelInstructionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CancelInstructionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelInstructionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CancelInstructionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ClearedOrderSummary">class <strong>ClearedOrderSummary</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ClearedOrderSummary">ClearedOrderSummary</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_count</strong></dt>
+</dl>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>commission</strong></dt>
+</dl>
+<dl><dt><strong>event_id</strong></dt>
+</dl>
+<dl><dt><strong>event_type_id</strong></dt>
+</dl>
+<dl><dt><strong>handicap</strong></dt>
+</dl>
+<dl><dt><strong>item_description</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>order_type</strong></dt>
+</dl>
+<dl><dt><strong>persistence_type</strong></dt>
+</dl>
+<dl><dt><strong>placed_data</strong></dt>
+</dl>
+<dl><dt><strong>price_matched</strong></dt>
+</dl>
+<dl><dt><strong>price_reduced</strong></dt>
+</dl>
+<dl><dt><strong>price_requested</strong></dt>
+</dl>
+<dl><dt><strong>profit</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<dl><dt><strong>settled_date</strong></dt>
+</dl>
+<dl><dt><strong>side</strong></dt>
+</dl>
+<dl><dt><strong>size_cancelled</strong></dt>
+</dl>
+<dl><dt><strong>size_settled</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_count': &lt;betfair.meta.field.Field object&gt;, 'bet_id': &lt;betfair.meta.field.Field object&gt;, 'commission': &lt;betfair.meta.field.Field object&gt;, 'event_id': &lt;betfair.meta.field.Field object&gt;, 'event_type_id': &lt;betfair.meta.field.Field object&gt;, 'handicap': &lt;betfair.meta.field.Field object&gt;, 'item_description': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'order_type': &lt;betfair.meta.field.Field object&gt;, 'persistence_type': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ClearedOrderSummary-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummary-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ClearedOrderSummary-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummary-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummary-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummary-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ClearedOrderSummaryReport">class <strong>ClearedOrderSummaryReport</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ClearedOrderSummaryReport">ClearedOrderSummaryReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>current_orders</strong></dt>
+</dl>
+<dl><dt><strong>more_available</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'current_orders': &lt;betfair.meta.field.ListField object&gt;, 'more_available': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ClearedOrderSummaryReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummaryReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ClearedOrderSummaryReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummaryReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummaryReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ClearedOrderSummaryReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Competition">class <strong>Competition</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#Competition">Competition</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>id</strong></dt>
+</dl>
+<dl><dt><strong>name</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'id': &lt;betfair.meta.field.Field object&gt;, 'name': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="Competition-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Competition-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="Competition-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Competition-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Competition-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Competition-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CompetitionResult">class <strong>CompetitionResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CompetitionResult">CompetitionResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>competition</strong></dt>
+</dl>
+<dl><dt><strong>competition_region</strong></dt>
+</dl>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'competition': &lt;betfair.meta.field.Field object&gt;, 'competition_region': &lt;betfair.meta.field.Field object&gt;, 'market_count': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CompetitionResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CompetitionResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CompetitionResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CompetitionResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CompetitionResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CompetitionResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CountryCodeResult">class <strong>CountryCodeResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CountryCodeResult">CountryCodeResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>country_code</strong></dt>
+</dl>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'country_code': &lt;betfair.meta.field.Field object&gt;, 'market_count': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CountryCodeResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CountryCodeResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CountryCodeResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CountryCodeResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CountryCodeResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CountryCodeResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CurrentOrderSummary">class <strong>CurrentOrderSummary</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CurrentOrderSummary">CurrentOrderSummary</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>average_price_matched</strong></dt>
+</dl>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>bsp_liability</strong></dt>
+</dl>
+<dl><dt><strong>handicap</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>matched_date</strong></dt>
+</dl>
+<dl><dt><strong>order_type</strong></dt>
+</dl>
+<dl><dt><strong>persistence_type</strong></dt>
+</dl>
+<dl><dt><strong>placed_date</strong></dt>
+</dl>
+<dl><dt><strong>price_size</strong></dt>
+</dl>
+<dl><dt><strong>regulator_auth_code</strong></dt>
+</dl>
+<dl><dt><strong>regulator_code</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<dl><dt><strong>side</strong></dt>
+</dl>
+<dl><dt><strong>size_cancelled</strong></dt>
+</dl>
+<dl><dt><strong>size_lapsed</strong></dt>
+</dl>
+<dl><dt><strong>size_matched</strong></dt>
+</dl>
+<dl><dt><strong>size_remaining</strong></dt>
+</dl>
+<dl><dt><strong>size_voided</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'average_price_matched': &lt;betfair.meta.field.Field object&gt;, 'bet_id': &lt;betfair.meta.field.Field object&gt;, 'bsp_liability': &lt;betfair.meta.field.Field object&gt;, 'handicap': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'matched_date': &lt;betfair.meta.field.Field object&gt;, 'order_type': &lt;betfair.meta.field.Field object&gt;, 'persistence_type': &lt;betfair.meta.field.Field object&gt;, 'placed_date': &lt;betfair.meta.field.Field object&gt;, 'price_size': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CurrentOrderSummary-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummary-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CurrentOrderSummary-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummary-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummary-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummary-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="CurrentOrderSummaryReport">class <strong>CurrentOrderSummaryReport</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#CurrentOrderSummaryReport">CurrentOrderSummaryReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>current_orders</strong></dt>
+</dl>
+<dl><dt><strong>more_available</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'current_orders': &lt;betfair.meta.field.ListField object&gt;, 'more_available': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="CurrentOrderSummaryReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummaryReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="CurrentOrderSummaryReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummaryReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummaryReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="CurrentOrderSummaryReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Event">class <strong>Event</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#Event">Event</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>country_code</strong></dt>
+</dl>
+<dl><dt><strong>id</strong></dt>
+</dl>
+<dl><dt><strong>name</strong></dt>
+</dl>
+<dl><dt><strong>open_date</strong></dt>
+</dl>
+<dl><dt><strong>timezone</strong></dt>
+</dl>
+<dl><dt><strong>venue</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'country_code': &lt;betfair.meta.field.Field object&gt;, 'id': &lt;betfair.meta.field.Field object&gt;, 'name': &lt;betfair.meta.field.Field object&gt;, 'open_date': &lt;betfair.meta.field.Field object&gt;, 'timezone': &lt;betfair.meta.field.Field object&gt;, 'venue': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="Event-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Event-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="Event-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Event-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Event-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Event-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="EventResult">class <strong>EventResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#EventResult">EventResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>event</strong></dt>
+</dl>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'event': &lt;betfair.meta.field.Field object&gt;, 'market_count': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="EventResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="EventResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="EventResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="EventResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="EventType">class <strong>EventType</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#EventType">EventType</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>id</strong></dt>
+</dl>
+<dl><dt><strong>name</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'id': &lt;betfair.meta.field.Field object&gt;, 'name': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="EventType-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="EventType-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="EventType-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="EventType-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventType-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventType-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="EventTypeResult">class <strong>EventTypeResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#EventTypeResult">EventTypeResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>event_type</strong></dt>
+</dl>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'event_type': &lt;betfair.meta.field.Field object&gt;, 'market_count': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="EventTypeResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="EventTypeResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="EventTypeResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="EventTypeResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventTypeResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="EventTypeResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ExBestOffersOverrides">class <strong>ExBestOffersOverrides</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ExBestOffersOverrides">ExBestOffersOverrides</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>best_prices_depth</strong></dt>
+</dl>
+<dl><dt><strong>rollup_liability_factor</strong></dt>
+</dl>
+<dl><dt><strong>rollup_liability_threshold</strong></dt>
+</dl>
+<dl><dt><strong>rollup_limit</strong></dt>
+</dl>
+<dl><dt><strong>rollup_model</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'best_prices_depth': &lt;betfair.meta.field.Field object&gt;, 'rollup_liability_factor': &lt;betfair.meta.field.Field object&gt;, 'rollup_liability_threshold': &lt;betfair.meta.field.Field object&gt;, 'rollup_limit': &lt;betfair.meta.field.Field object&gt;, 'rollup_model': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ExBestOffersOverrides-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ExBestOffersOverrides-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ExBestOffersOverrides-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ExBestOffersOverrides-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ExBestOffersOverrides-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ExBestOffersOverrides-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ExchangePrices">class <strong>ExchangePrices</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ExchangePrices">ExchangePrices</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>available_to_back</strong></dt>
+</dl>
+<dl><dt><strong>available_to_lay</strong></dt>
+</dl>
+<dl><dt><strong>traded_volume</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'available_to_back': &lt;betfair.meta.field.ListField object&gt;, 'available_to_lay': &lt;betfair.meta.field.ListField object&gt;, 'traded_volume': &lt;betfair.meta.field.ListField object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ExchangePrices-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ExchangePrices-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ExchangePrices-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ExchangePrices-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ExchangePrices-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ExchangePrices-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ItemDescription">class <strong>ItemDescription</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ItemDescription">ItemDescription</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>event_desc</strong></dt>
+</dl>
+<dl><dt><strong>event_type_desc</strong></dt>
+</dl>
+<dl><dt><strong>market_desc</strong></dt>
+</dl>
+<dl><dt><strong>market_start_Time</strong></dt>
+</dl>
+<dl><dt><strong>number_of_winners</strong></dt>
+</dl>
+<dl><dt><strong>runner_desc</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'event_desc': &lt;betfair.meta.field.Field object&gt;, 'event_type_desc': &lt;betfair.meta.field.Field object&gt;, 'market_desc': &lt;betfair.meta.field.Field object&gt;, 'market_start_Time': &lt;betfair.meta.field.Field object&gt;, 'number_of_winners': &lt;betfair.meta.field.Field object&gt;, 'runner_desc': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ItemDescription-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ItemDescription-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ItemDescription-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ItemDescription-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ItemDescription-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ItemDescription-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="LimitOnCloseOrder">class <strong>LimitOnCloseOrder</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#LimitOnCloseOrder">LimitOnCloseOrder</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>liability</strong></dt>
+</dl>
+<dl><dt><strong>price</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'liability': &lt;betfair.meta.field.Field object&gt;, 'price': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="LimitOnCloseOrder-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="LimitOnCloseOrder-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="LimitOnCloseOrder-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="LimitOnCloseOrder-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="LimitOnCloseOrder-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="LimitOnCloseOrder-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="LimitOrder">class <strong>LimitOrder</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#LimitOrder">LimitOrder</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>persistence_type</strong></dt>
+</dl>
+<dl><dt><strong>price</strong></dt>
+</dl>
+<dl><dt><strong>size</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'persistence_type': &lt;betfair.meta.field.Field object&gt;, 'price': &lt;betfair.meta.field.Field object&gt;, 'size': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="LimitOrder-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="LimitOrder-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="LimitOrder-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="LimitOrder-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="LimitOrder-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="LimitOrder-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketBook">class <strong>MarketBook</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketBook">MarketBook</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_delay</strong></dt>
+</dl>
+<dl><dt><strong>bsp_reconciled</strong></dt>
+</dl>
+<dl><dt><strong>complete</strong></dt>
+</dl>
+<dl><dt><strong>cross_matching</strong></dt>
+</dl>
+<dl><dt><strong>inplay</strong></dt>
+</dl>
+<dl><dt><strong>is_market_data_delayed</strong></dt>
+</dl>
+<dl><dt><strong>last_match_time</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>number_of_active_runners</strong></dt>
+</dl>
+<dl><dt><strong>number_of_runners</strong></dt>
+</dl>
+<dl><dt><strong>number_of_winners</strong></dt>
+</dl>
+<dl><dt><strong>runners</strong></dt>
+</dl>
+<dl><dt><strong>runners_voidable</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<dl><dt><strong>total_available</strong></dt>
+</dl>
+<dl><dt><strong>total_matched</strong></dt>
+</dl>
+<dl><dt><strong>version</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_delay': &lt;betfair.meta.field.Field object&gt;, 'bsp_reconciled': &lt;betfair.meta.field.Field object&gt;, 'complete': &lt;betfair.meta.field.Field object&gt;, 'cross_matching': &lt;betfair.meta.field.Field object&gt;, 'inplay': &lt;betfair.meta.field.Field object&gt;, 'is_market_data_delayed': &lt;betfair.meta.field.Field object&gt;, 'last_match_time': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'number_of_active_runners': &lt;betfair.meta.field.Field object&gt;, 'number_of_runners': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketBook-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketBook-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketBook-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketBook-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketBook-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketBook-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketCatalogue">class <strong>MarketCatalogue</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketCatalogue">MarketCatalogue</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>competition</strong></dt>
+</dl>
+<dl><dt><strong>description</strong></dt>
+</dl>
+<dl><dt><strong>event</strong></dt>
+</dl>
+<dl><dt><strong>event_type</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>market_name</strong></dt>
+</dl>
+<dl><dt><strong>market_start_time</strong></dt>
+</dl>
+<dl><dt><strong>runners</strong></dt>
+</dl>
+<dl><dt><strong>total_matched</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'competition': &lt;betfair.meta.field.Field object&gt;, 'description': &lt;betfair.meta.field.Field object&gt;, 'event': &lt;betfair.meta.field.Field object&gt;, 'event_type': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'market_name': &lt;betfair.meta.field.Field object&gt;, 'market_start_time': &lt;betfair.meta.field.Field object&gt;, 'runners': &lt;betfair.meta.field.ListField object&gt;, 'total_matched': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketCatalogue-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketCatalogue-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketCatalogue-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketCatalogue-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketCatalogue-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketCatalogue-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketDescription">class <strong>MarketDescription</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketDescription">MarketDescription</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>betting_type</strong></dt>
+</dl>
+<dl><dt><strong>bsp_market</strong></dt>
+</dl>
+<dl><dt><strong>clarifications</strong></dt>
+</dl>
+<dl><dt><strong>discount_allowed</strong></dt>
+</dl>
+<dl><dt><strong>market_base_rate</strong></dt>
+</dl>
+<dl><dt><strong>market_time</strong></dt>
+</dl>
+<dl><dt><strong>market_type</strong></dt>
+</dl>
+<dl><dt><strong>persistence_enabled</strong></dt>
+</dl>
+<dl><dt><strong>regulator</strong></dt>
+</dl>
+<dl><dt><strong>rules</strong></dt>
+</dl>
+<dl><dt><strong>rules_has_date</strong></dt>
+</dl>
+<dl><dt><strong>settle_time</strong></dt>
+</dl>
+<dl><dt><strong>suspend_time</strong></dt>
+</dl>
+<dl><dt><strong>turn_in_play_enabled</strong></dt>
+</dl>
+<dl><dt><strong>wallet</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'betting_type': &lt;betfair.meta.field.Field object&gt;, 'bsp_market': &lt;betfair.meta.field.Field object&gt;, 'clarifications': &lt;betfair.meta.field.Field object&gt;, 'discount_allowed': &lt;betfair.meta.field.Field object&gt;, 'market_base_rate': &lt;betfair.meta.field.Field object&gt;, 'market_time': &lt;betfair.meta.field.Field object&gt;, 'market_type': &lt;betfair.meta.field.Field object&gt;, 'persistence_enabled': &lt;betfair.meta.field.Field object&gt;, 'regulator': &lt;betfair.meta.field.Field object&gt;, 'rules': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketDescription-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketDescription-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketDescription-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketDescription-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketDescription-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketDescription-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketFilter">class <strong>MarketFilter</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketFilter">MarketFilter</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bsp_only</strong></dt>
+</dl>
+<dl><dt><strong>competition_ids</strong></dt>
+</dl>
+<dl><dt><strong>event_ids</strong></dt>
+</dl>
+<dl><dt><strong>event_type_ids</strong></dt>
+</dl>
+<dl><dt><strong>exchange_ids</strong></dt>
+</dl>
+<dl><dt><strong>in_play_only</strong></dt>
+</dl>
+<dl><dt><strong>market_betting_types</strong></dt>
+</dl>
+<dl><dt><strong>market_countries</strong></dt>
+</dl>
+<dl><dt><strong>market_ids</strong></dt>
+</dl>
+<dl><dt><strong>market_start_time</strong></dt>
+</dl>
+<dl><dt><strong>market_type_codes</strong></dt>
+</dl>
+<dl><dt><strong>text_query</strong></dt>
+</dl>
+<dl><dt><strong>turn_in_play_enabled</strong></dt>
+</dl>
+<dl><dt><strong>venues</strong></dt>
+</dl>
+<dl><dt><strong>with_orders</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bsp_only': &lt;betfair.meta.field.Field object&gt;, 'competition_ids': &lt;betfair.meta.field.ListField object&gt;, 'event_ids': &lt;betfair.meta.field.ListField object&gt;, 'event_type_ids': &lt;betfair.meta.field.ListField object&gt;, 'exchange_ids': &lt;betfair.meta.field.ListField object&gt;, 'in_play_only': &lt;betfair.meta.field.Field object&gt;, 'market_betting_types': &lt;betfair.meta.field.ListField object&gt;, 'market_countries': &lt;betfair.meta.field.ListField object&gt;, 'market_ids': &lt;betfair.meta.field.ListField object&gt;, 'market_start_time': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketFilter-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketFilter-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketFilter-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketFilter-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketFilter-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketFilter-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketOnCloseOrder">class <strong>MarketOnCloseOrder</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketOnCloseOrder">MarketOnCloseOrder</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>liability</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'liability': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketOnCloseOrder-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketOnCloseOrder-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketOnCloseOrder-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketOnCloseOrder-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketOnCloseOrder-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketOnCloseOrder-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketProfitAndLoss">class <strong>MarketProfitAndLoss</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketProfitAndLoss">MarketProfitAndLoss</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>commission_applied</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>profit_and_losses</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'commission_applied': &lt;betfair.meta.field.Field object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'profit_and_losses': &lt;betfair.meta.field.ListField object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketProfitAndLoss-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketProfitAndLoss-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketProfitAndLoss-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketProfitAndLoss-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketProfitAndLoss-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketProfitAndLoss-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="MarketTypeResult">class <strong>MarketTypeResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#MarketTypeResult">MarketTypeResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<dl><dt><strong>market_type</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'market_count': &lt;betfair.meta.field.Field object&gt;, 'market_type': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="MarketTypeResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="MarketTypeResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="MarketTypeResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="MarketTypeResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketTypeResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="MarketTypeResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Match">class <strong>Match</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#Match">Match</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>match_date</strong></dt>
+</dl>
+<dl><dt><strong>match_id</strong></dt>
+</dl>
+<dl><dt><strong>price</strong></dt>
+</dl>
+<dl><dt><strong>side</strong></dt>
+</dl>
+<dl><dt><strong>size</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_id': &lt;betfair.meta.field.Field object&gt;, 'match_date': &lt;betfair.meta.field.Field object&gt;, 'match_id': &lt;betfair.meta.field.Field object&gt;, 'price': &lt;betfair.meta.field.Field object&gt;, 'side': &lt;betfair.meta.field.Field object&gt;, 'size': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="Match-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Match-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="Match-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Match-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Match-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Match-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Order">class <strong>Order</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#Order">Order</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>avg_price_matched</strong></dt>
+</dl>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>bsp_liability</strong></dt>
+</dl>
+<dl><dt><strong>order_type</strong></dt>
+</dl>
+<dl><dt><strong>persistence_type</strong></dt>
+</dl>
+<dl><dt><strong>placed_date</strong></dt>
+</dl>
+<dl><dt><strong>price</strong></dt>
+</dl>
+<dl><dt><strong>side</strong></dt>
+</dl>
+<dl><dt><strong>size</strong></dt>
+</dl>
+<dl><dt><strong>size_cancelled</strong></dt>
+</dl>
+<dl><dt><strong>size_lapsed</strong></dt>
+</dl>
+<dl><dt><strong>size_matched</strong></dt>
+</dl>
+<dl><dt><strong>size_remaining</strong></dt>
+</dl>
+<dl><dt><strong>size_voided</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'avg_price_matched': &lt;betfair.meta.field.Field object&gt;, 'bet_id': &lt;betfair.meta.field.Field object&gt;, 'bsp_liability': &lt;betfair.meta.field.Field object&gt;, 'order_type': &lt;betfair.meta.field.Field object&gt;, 'persistence_type': &lt;betfair.meta.field.Field object&gt;, 'placed_date': &lt;betfair.meta.field.Field object&gt;, 'price': &lt;betfair.meta.field.Field object&gt;, 'side': &lt;betfair.meta.field.Field object&gt;, 'size': &lt;betfair.meta.field.Field object&gt;, 'size_cancelled': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="Order-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Order-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="Order-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Order-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Order-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Order-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="PlaceExecutionReport">class <strong>PlaceExecutionReport</strong></a>(<a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#PlaceExecutionReport">PlaceExecutionReport</a></dd>
+<dd><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>instruction_reports</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'customer_ref': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction_reports': &lt;betfair.meta.field.ListField object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>:<br>
+<dl><dt><strong>customer_ref</strong></dt>
+</dl>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="PlaceExecutionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="PlaceExecutionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="PlaceExecutionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="PlaceExecutionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceExecutionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceExecutionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="PlaceInstruction">class <strong>PlaceInstruction</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#PlaceInstruction">PlaceInstruction</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>handicap</strong></dt>
+</dl>
+<dl><dt><strong>limit_on_close_order</strong></dt>
+</dl>
+<dl><dt><strong>limit_order</strong></dt>
+</dl>
+<dl><dt><strong>market_on_close_order</strong></dt>
+</dl>
+<dl><dt><strong>order_type</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<dl><dt><strong>side</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'handicap': &lt;betfair.meta.field.Field object&gt;, 'limit_on_close_order': &lt;betfair.meta.field.Field object&gt;, 'limit_order': &lt;betfair.meta.field.Field object&gt;, 'market_on_close_order': &lt;betfair.meta.field.Field object&gt;, 'order_type': &lt;betfair.meta.field.Field object&gt;, 'selection_id': &lt;betfair.meta.field.Field object&gt;, 'side': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="PlaceInstruction-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="PlaceInstruction-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="PlaceInstruction-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="PlaceInstruction-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceInstruction-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceInstruction-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="PlaceInstructionReport">class <strong>PlaceInstructionReport</strong></a>(<a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#PlaceInstructionReport">PlaceInstructionReport</a></dd>
+<dd><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>average_price_matched</strong></dt>
+</dl>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>instruction</strong></dt>
+</dl>
+<dl><dt><strong>placed_date</strong></dt>
+</dl>
+<dl><dt><strong>size_matched</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'average_price_matched': &lt;betfair.meta.field.Field object&gt;, 'bet_id': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction': &lt;betfair.meta.field.Field object&gt;, 'placed_date': &lt;betfair.meta.field.Field object&gt;, 'size_matched': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>:<br>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="PlaceInstructionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="PlaceInstructionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="PlaceInstructionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="PlaceInstructionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceInstructionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PlaceInstructionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="PriceProjection">class <strong>PriceProjection</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#PriceProjection">PriceProjection</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>ex_best_offer_overrides</strong></dt>
+</dl>
+<dl><dt><strong>price_data</strong></dt>
+</dl>
+<dl><dt><strong>rollover_stakes</strong></dt>
+</dl>
+<dl><dt><strong>virtualize</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'ex_best_offer_overrides': &lt;betfair.meta.field.Field object&gt;, 'price_data': &lt;betfair.meta.field.ListField object&gt;, 'rollover_stakes': &lt;betfair.meta.field.Field object&gt;, 'virtualize': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="PriceProjection-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="PriceProjection-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="PriceProjection-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="PriceProjection-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PriceProjection-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PriceProjection-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="PriceSize">class <strong>PriceSize</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#PriceSize">PriceSize</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>price</strong></dt>
+</dl>
+<dl><dt><strong>size</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'price': &lt;betfair.meta.field.Field object&gt;, 'size': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="PriceSize-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="PriceSize-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="PriceSize-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="PriceSize-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PriceSize-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="PriceSize-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ReplaceExecutionReport">class <strong>ReplaceExecutionReport</strong></a>(<a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ReplaceExecutionReport">ReplaceExecutionReport</a></dd>
+<dd><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>instruction_reports</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'customer_ref': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction_reports': &lt;betfair.meta.field.ListField object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>:<br>
+<dl><dt><strong>customer_ref</strong></dt>
+</dl>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ReplaceExecutionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ReplaceExecutionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ReplaceExecutionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ReplaceExecutionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceExecutionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceExecutionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ReplaceInstruction">class <strong>ReplaceInstruction</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ReplaceInstruction">ReplaceInstruction</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>new_price</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_id': &lt;betfair.meta.field.Field object&gt;, 'new_price': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ReplaceInstruction-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ReplaceInstruction-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ReplaceInstruction-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ReplaceInstruction-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceInstruction-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceInstruction-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="ReplaceInstructionReport">class <strong>ReplaceInstructionReport</strong></a>(<a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#ReplaceInstructionReport">ReplaceInstructionReport</a></dd>
+<dd><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>cancel_instruction_report</strong></dt>
+</dl>
+<dl><dt><strong>place_instruction_report</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'cancel_instruction_report': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'place_instruction_report': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>:<br>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="ReplaceInstructionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="ReplaceInstructionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="ReplaceInstructionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="ReplaceInstructionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceInstructionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="ReplaceInstructionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="Runner">class <strong>Runner</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#Runner">Runner</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>adjustment_factor</strong></dt>
+</dl>
+<dl><dt><strong>ex</strong></dt>
+</dl>
+<dl><dt><strong>handicap</strong></dt>
+</dl>
+<dl><dt><strong>last_price_traded</strong></dt>
+</dl>
+<dl><dt><strong>matches</strong></dt>
+</dl>
+<dl><dt><strong>orders</strong></dt>
+</dl>
+<dl><dt><strong>removal_date</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<dl><dt><strong>sp</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<dl><dt><strong>total_matched</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'adjustment_factor': &lt;betfair.meta.field.Field object&gt;, 'ex': &lt;betfair.meta.field.Field object&gt;, 'handicap': &lt;betfair.meta.field.Field object&gt;, 'last_price_traded': &lt;betfair.meta.field.Field object&gt;, 'matches': &lt;betfair.meta.field.ListField object&gt;, 'orders': &lt;betfair.meta.field.ListField object&gt;, 'removal_date': &lt;betfair.meta.field.Field object&gt;, 'selection_id': &lt;betfair.meta.field.Field object&gt;, 'sp': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;, ...}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="Runner-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="Runner-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="Runner-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="Runner-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Runner-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="Runner-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="RunnerCatalog">class <strong>RunnerCatalog</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#RunnerCatalog">RunnerCatalog</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>handicap</strong></dt>
+</dl>
+<dl><dt><strong>metadata</strong></dt>
+</dl>
+<dl><dt><strong>runner_name</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<dl><dt><strong>sort_priority</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'handicap': &lt;betfair.meta.field.Field object&gt;, 'metadata': &lt;betfair.meta.field.Field object&gt;, 'runner_name': &lt;betfair.meta.field.Field object&gt;, 'selection_id': &lt;betfair.meta.field.Field object&gt;, 'sort_priority': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="RunnerCatalog-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="RunnerCatalog-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="RunnerCatalog-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="RunnerCatalog-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="RunnerCatalog-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="RunnerCatalog-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="RunnerProfitAndLoss">class <strong>RunnerProfitAndLoss</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#RunnerProfitAndLoss">RunnerProfitAndLoss</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>if_lose</strong></dt>
+</dl>
+<dl><dt><strong>if_win</strong></dt>
+</dl>
+<dl><dt><strong>selection_id</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'if_lose': &lt;betfair.meta.field.Field object&gt;, 'if_win': &lt;betfair.meta.field.Field object&gt;, 'selection_id': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="RunnerProfitAndLoss-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="RunnerProfitAndLoss-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="RunnerProfitAndLoss-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="RunnerProfitAndLoss-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="RunnerProfitAndLoss-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="RunnerProfitAndLoss-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="StartingPrices">class <strong>StartingPrices</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#StartingPrices">StartingPrices</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>actual_SP</strong></dt>
+</dl>
+<dl><dt><strong>back_state_taken</strong></dt>
+</dl>
+<dl><dt><strong>far_price</strong></dt>
+</dl>
+<dl><dt><strong>lay_liability_taken</strong></dt>
+</dl>
+<dl><dt><strong>near_price</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'actual_SP': &lt;betfair.meta.field.Field object&gt;, 'back_state_taken': &lt;betfair.meta.field.Field object&gt;, 'far_price': &lt;betfair.meta.field.Field object&gt;, 'lay_liability_taken': &lt;betfair.meta.field.Field object&gt;, 'near_price': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="StartingPrices-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="StartingPrices-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="StartingPrices-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="StartingPrices-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="StartingPrices-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="StartingPrices-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="TimeRange">class <strong>TimeRange</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#TimeRange">TimeRange</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>from_</strong></dt>
+</dl>
+<dl><dt><strong>to</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'from_': &lt;betfair.meta.field.Field object&gt;, 'to': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="TimeRange-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="TimeRange-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="TimeRange-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="TimeRange-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="TimeRange-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="TimeRange-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="TimeRangeResult">class <strong>TimeRangeResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#TimeRangeResult">TimeRangeResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<dl><dt><strong>time_range</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'market_count': &lt;betfair.meta.field.Field object&gt;, 'time_range': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="TimeRangeResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="TimeRangeResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="TimeRangeResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="TimeRangeResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="TimeRangeResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="TimeRangeResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="UpdateExecutionReport">class <strong>UpdateExecutionReport</strong></a>(<a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#UpdateExecutionReport">UpdateExecutionReport</a></dd>
+<dd><a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>instruction_reports</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'customer_ref': &lt;betfair.meta.field.Field object&gt;, 'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction_reports': &lt;betfair.meta.field.ListField object&gt;, 'market_id': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseExecutionReport">BaseExecutionReport</a>:<br>
+<dl><dt><strong>customer_ref</strong></dt>
+</dl>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>market_id</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="UpdateExecutionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="UpdateExecutionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="UpdateExecutionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="UpdateExecutionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateExecutionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateExecutionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="UpdateInstruction">class <strong>UpdateInstruction</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#UpdateInstruction">UpdateInstruction</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>bet_id</strong></dt>
+</dl>
+<dl><dt><strong>new_persistence_type</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'bet_id': &lt;betfair.meta.field.Field object&gt;, 'new_persistence_type': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="UpdateInstruction-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="UpdateInstruction-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="UpdateInstruction-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="UpdateInstruction-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateInstruction-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateInstruction-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="UpdateInstructionReport">class <strong>UpdateInstructionReport</strong></a>(<a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#UpdateInstructionReport">UpdateInstructionReport</a></dd>
+<dd><a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>instruction</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'error_code': &lt;betfair.meta.field.Field object&gt;, 'instruction': &lt;betfair.meta.field.Field object&gt;, 'status': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.models.html#BaseInstructionReport">BaseInstructionReport</a>:<br>
+<dl><dt><strong>error_code</strong></dt>
+</dl>
+<dl><dt><strong>status</strong></dt>
+</dl>
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="UpdateInstructionReport-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="UpdateInstructionReport-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="UpdateInstructionReport-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="UpdateInstructionReport-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateInstructionReport-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="UpdateInstructionReport-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table> <p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#ffc8d8">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#000000" face="helvetica, arial"><a name="VenueResult">class <strong>VenueResult</strong></a>(<a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>)</font></td></tr>
+    
+<tr><td bgcolor="#ffc8d8"><tt>&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt>Method resolution order:</dt>
+<dd><a href="betfair.models.html#VenueResult">VenueResult</a></dd>
+<dd><a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a></dd>
+<dd><a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a></dd>
+<dd><a href="__builtin__.html#object">__builtin__.object</a></dd>
+</dl>
+<hr>
+Data descriptors defined here:<br>
+<dl><dt><strong>market_count</strong></dt>
+</dl>
+<dl><dt><strong>venue</strong></dt>
+</dl>
+<hr>
+Data and other attributes defined here:<br>
+<dl><dt><strong>_fields</strong> = {'market_count': &lt;betfair.meta.field.Field object&gt;, 'venue': &lt;betfair.meta.field.Field object&gt;}</dl>
+
+<hr>
+Methods inherited from <a href="betfair.model.html#BetfairModel">betfair.model.BetfairModel</a>:<br>
+<dl><dt><a name="VenueResult-serialize_key"><strong>serialize_key</strong></a>(self, key)</dt></dl>
+
+<dl><dt><a name="VenueResult-unserialize_key"><strong>unserialize_key</strong></a>(self, key)</dt></dl>
+
+<hr>
+Methods inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><a name="VenueResult-__init__"><strong>__init__</strong></a>(self, **kwargs)</dt></dl>
+
+<dl><dt><a name="VenueResult-check_complete"><strong>check_complete</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="VenueResult-serialize"><strong>serialize</strong></a>(self)</dt></dl>
+
+<dl><dt><a name="VenueResult-unserialize"><strong>unserialize</strong></a>(self, kwargs)</dt></dl>
+
+<hr>
+Data descriptors inherited from <a href="betfair.meta.model.html#Model">betfair.meta.model.Model</a>:<br>
+<dl><dt><strong>__dict__</strong></dt>
+<dd><tt>dictionary&nbsp;for&nbsp;instance&nbsp;variables&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+<dl><dt><strong>__weakref__</strong></dt>
+<dd><tt>list&nbsp;of&nbsp;weak&nbsp;references&nbsp;to&nbsp;the&nbsp;object&nbsp;(if&nbsp;defined)</tt></dd>
+</dl>
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>datetime_type</strong> = &lt;betfair.meta.datatype.DataType object&gt;</td></tr></table>
+</body></html>

--- a/docs/betfair.utils.html
+++ b/docs/betfair.utils.html
@@ -1,0 +1,66 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module betfair.utils</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="betfair.html"><font color="#ffffff">betfair</font></a>.utils</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/betfair/utils.py">/home/james/projects/betfair.py/betfair/utils.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="collections.html">collections</a><br>
+<a href="decorator.html">decorator</a><br>
+</td><td width="25%" valign=top><a href="betfair.exceptions.html">betfair.exceptions</a><br>
+<a href="httplib.html">httplib</a><br>
+</td><td width="25%" valign=top><a href="inflection.html">inflection</a><br>
+<a href="six.html">six</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-check_status_code"><strong>check_status_code</strong></a>(response, codes<font color="#909090">=None</font>)</dt><dd><tt>Check&nbsp;HTTP&nbsp;status&nbsp;code&nbsp;and&nbsp;raise&nbsp;exception&nbsp;if&nbsp;incorrect.<br>
+&nbsp;<br>
+:param&nbsp;Response&nbsp;response:&nbsp;HTTP&nbsp;response<br>
+:param&nbsp;codes:&nbsp;List&nbsp;of&nbsp;accepted&nbsp;codes&nbsp;or&nbsp;callable<br>
+:raises:&nbsp;BetfairError&nbsp;if&nbsp;code&nbsp;invalid</tt></dd></dl>
+ <dl><dt><a name="-get_chunks"><strong>get_chunks</strong></a>(sequence, chunk_size)</dt><dd><tt>Split&nbsp;sequence&nbsp;into&nbsp;chunks.<br>
+&nbsp;<br>
+:param&nbsp;list&nbsp;sequence:<br>
+:param&nbsp;int&nbsp;chunk_size:</tt></dd></dl>
+ <dl><dt><a name="-get_kwargs"><strong>get_kwargs</strong></a>(kwargs)</dt><dd><tt>Get&nbsp;all&nbsp;keys&nbsp;and&nbsp;values&nbsp;from&nbsp;dictionary&nbsp;where&nbsp;key&nbsp;is&nbsp;not&nbsp;`self`.<br>
+&nbsp;<br>
+:param&nbsp;dict&nbsp;kwargs:&nbsp;Input&nbsp;parameters</tt></dd></dl>
+ <dl><dt><a name="-make_payload"><strong>make_payload</strong></a>(method, params)</dt><dd><tt>Build&nbsp;Betfair&nbsp;JSON-RPC&nbsp;payload.<br>
+&nbsp;<br>
+:param&nbsp;str&nbsp;method:&nbsp;Betfair&nbsp;endpoint<br>
+:param&nbsp;dict&nbsp;params:&nbsp;Request&nbsp;parameters</tt></dd></dl>
+ <dl><dt><a name="-process_result"><strong>process_result</strong></a>(result, model<font color="#909090">=None</font>)</dt><dd><tt>Cast&nbsp;response&nbsp;JSON&nbsp;to&nbsp;Betfair&nbsp;model(s).<br>
+&nbsp;<br>
+:param&nbsp;result:&nbsp;Betfair&nbsp;response&nbsp;JSON<br>
+:param&nbsp;BetfairModel&nbsp;model:&nbsp;Deserialization&nbsp;format;&nbsp;if&nbsp;`None`,&nbsp;return&nbsp;raw<br>
+&nbsp;&nbsp;&nbsp;&nbsp;JSON</tt></dd></dl>
+ <dl><dt><a name="-requires_login"><strong>requires_login</strong></a>(func)</dt><dd><tt>Decorator&nbsp;to&nbsp;check&nbsp;that&nbsp;the&nbsp;user&nbsp;is&nbsp;logged&nbsp;in.&nbsp;Raises&nbsp;`BetfairError`<br>
+if&nbsp;instance&nbsp;variable&nbsp;`session_token`&nbsp;is&nbsp;absent.</tt></dd></dl>
+ <dl><dt><a name="-result_or_error"><strong>result_or_error</strong></a>(response)</dt><dd><tt>Get&nbsp;`result`&nbsp;field&nbsp;from&nbsp;Betfair&nbsp;response&nbsp;or&nbsp;raise&nbsp;exception&nbsp;if&nbsp;not<br>
+found.<br>
+&nbsp;<br>
+:param&nbsp;Response&nbsp;response:<br>
+:raises:&nbsp;BetfairAPIError&nbsp;if&nbsp;no&nbsp;results&nbsp;passed</tt></dd></dl>
+ <dl><dt><a name="-serialize_params"><strong>serialize_params</strong></a>(params)</dt><dd><tt>Serialize&nbsp;input&nbsp;parameters&nbsp;to&nbsp;Betfair-formatted&nbsp;JSON.<br>
+&nbsp;<br>
+:param&nbsp;dict&nbsp;params:&nbsp;Request&nbsp;parameters</tt></dd></dl>
+</td></tr></table>
+</body></html>

--- a/docs/tasks.html
+++ b/docs/tasks.html
@@ -1,0 +1,28 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tasks</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>tasks</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tasks.py">/home/james/projects/betfair.py/tasks.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>DEFAULT_BITS</strong> = 2048<br>
+<strong>DEFAULT_NAME</strong> = 'certs/betfair'<br>
+<strong>generate_cert</strong> = &lt;Task 'generate_cert'&gt;<br>
+<strong>generate_key</strong> = &lt;Task 'generate_key'&gt;<br>
+<strong>generate_pem</strong> = &lt;Task 'generate_pem'&gt;<br>
+<strong>sign_cert</strong> = &lt;Task 'sign_cert'&gt;<br>
+<strong>ssl</strong> = &lt;Task 'ssl'&gt;</td></tr></table>
+</body></html>

--- a/docs/tests.fixtures.html
+++ b/docs/tests.fixtures.html
@@ -1,0 +1,41 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tests.fixtures</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="tests.html"><font color="#ffffff">tests</font></a>.fixtures</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/fixtures.py">/home/james/projects/betfair.py/tests/fixtures.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.betfair.html">betfair.betfair</a><br>
+</td><td width="25%" valign=top><a href="os.html">os</a><br>
+</td><td width="25%" valign=top><a href="pytest.html">pytest</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-client"><strong>client</strong></a>()</dt></dl>
+ <dl><dt><a name="-logged_in_client"><strong>logged_in_client</strong></a>(client)</dt></dl>
+</td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#55aa55">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Data</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#55aa55"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><strong>login_required_methods</strong> = ['keep_alive', 'logout', 'list_event_types', 'list_competitions', 'list_time_ranges', 'list_events', 'list_market_types', 'list_countries', 'list_venues', 'list_market_catalogue', 'list_market_book', 'list_market_profit_and_loss', 'list_current_orders', 'list_cleared_orders', 'place_orders', 'cancel_orders', 'replace_orders', 'update_orders']</td></tr></table>
+</body></html>

--- a/docs/tests.html
+++ b/docs/tests.html
@@ -1,0 +1,27 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: package tests</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong>tests</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/__init__.py">/home/james/projects/betfair.py/tests/__init__.py</a></font></td></tr></table>
+    <p></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Package Contents</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="tests.fixtures.html">fixtures</a><br>
+<a href="tests.test_betfair.html">test_betfair</a><br>
+</td><td width="25%" valign=top><a href="tests.test_models.html">test_models</a><br>
+<a href="tests.test_utils.html">test_utils</a><br>
+</td><td width="25%" valign=top><a href="tests.utils.html">utils</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table>
+</body></html>

--- a/docs/tests.test_betfair.html
+++ b/docs/tests.test_betfair.html
@@ -1,0 +1,46 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tests.test_betfair</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="tests.html"><font color="#ffffff">tests</font></a>.test_betfair</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/test_betfair.py">/home/james/projects/betfair.py/tests/test_betfair.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="betfair.betfair.html">betfair.betfair</a><br>
+<a href="betfair.exceptions.html">betfair.exceptions</a><br>
+</td><td width="25%" valign=top><a href="tests.fixtures.html">tests.fixtures</a><br>
+<a href="inspect.html">inspect</a><br>
+</td><td width="25%" valign=top><a href="itertools.html">itertools</a><br>
+<a href="pytest.html">pytest</a><br>
+</td><td width="25%" valign=top><a href="requests.html">requests</a><br>
+<a href="tests.utils.html">tests.utils</a><br>
+</td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-test_client_init"><strong>test_client_init</strong></a>(client)</dt></dl>
+ <dl><dt><a name="-test_headers"><strong>test_headers</strong></a>(client)</dt></dl>
+ <dl><dt><a name="-test_keepalive_failure"><strong>test_keepalive_failure</strong></a>(logged_in_client, keepalive_failure)</dt></dl>
+ <dl><dt><a name="-test_keepalive_success"><strong>test_keepalive_success</strong></a>(logged_in_client, keepalive_success)</dt></dl>
+ <dl><dt><a name="-test_login_error"><strong>test_login_error</strong></a>(client, login_failure)</dt></dl>
+ <dl><dt><a name="-test_login_success"><strong>test_login_success</strong></a>(client, login_success)</dt></dl>
+ <dl><dt><a name="-test_logout_failure"><strong>test_logout_failure</strong></a>(logged_in_client, logout_failure)</dt></dl>
+ <dl><dt><a name="-test_logout_success"><strong>test_logout_success</strong></a>(logged_in_client, logout_success)</dt></dl>
+ <dl><dt><a name="-test_requires_login"><strong>test_requires_login</strong></a>(method_name, client, logged_in_client, monkeypatch)</dt></dl>
+</td></tr></table>
+</body></html>

--- a/docs/tests.test_models.html
+++ b/docs/tests.test_models.html
@@ -1,0 +1,33 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tests.test_models</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="tests.html"><font color="#ffffff">tests</font></a>.test_models</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/test_models.py">/home/james/projects/betfair.py/tests/test_models.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="pytest.html">pytest</a><br>
+</td><td width="25%" valign=top></td><td width="25%" valign=top></td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><a name="-model"><strong>model</strong></a>()</dt></dl>
+ <dl><dt><a name="-test_field_inflection"><strong>test_field_inflection</strong></a>(model)</dt></dl>
+ <dl><dt><a name="-test_field_trailing_underscore"><strong>test_field_trailing_underscore</strong></a>(model)</dt></dl>
+</td></tr></table>
+</body></html>

--- a/docs/tests.test_utils.html
+++ b/docs/tests.test_utils.html
@@ -1,0 +1,15 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tests.test_utils</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="tests.html"><font color="#ffffff">tests</font></a>.test_utils</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/test_utils.py">/home/james/projects/betfair.py/tests/test_utils.py</a></font></td></tr></table>
+    <p></p>
+
+</body></html>

--- a/docs/tests.utils.html
+++ b/docs/tests.utils.html
@@ -1,0 +1,34 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html><head><title>Python: module tests.utils</title>
+<meta charset="utf-8">
+</head><body bgcolor="#f0f0f8">
+
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="heading">
+<tr bgcolor="#7799ee">
+<td valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial">&nbsp;<br><big><big><strong><a href="tests.html"><font color="#ffffff">tests</font></a>.utils</strong></big></big></font></td
+><td align=right valign=bottom
+><font color="#ffffff" face="helvetica, arial"><a href=".">index</a><br><a href="file:/home/james/projects/betfair.py/tests/utils.py">/home/james/projects/betfair.py/tests/utils.py</a></font></td></tr></table>
+    <p><tt>#&nbsp;-*-&nbsp;coding:&nbsp;utf-8&nbsp;-*-</tt></p>
+<p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#aa55cc">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Modules</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#aa55cc"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><table width="100%" summary="list"><tr><td width="25%" valign=top><a href="json.html">json</a><br>
+</td><td width="25%" valign=top><a href="pytest.html">pytest</a><br>
+</td><td width="25%" valign=top><a href="responses.html">responses</a><br>
+</td><td width="25%" valign=top></td></tr></table></td></tr></table><p>
+<table width="100%" cellspacing=0 cellpadding=2 border=0 summary="section">
+<tr bgcolor="#eeaa77">
+<td colspan=3 valign=bottom>&nbsp;<br>
+<font color="#ffffff" face="helvetica, arial"><big><strong>Functions</strong></big></font></td></tr>
+    
+<tr><td bgcolor="#eeaa77"><tt>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</tt></td><td>&nbsp;</td>
+<td width="100%"><dl><dt><strong>noop</strong> <em>lambda</em> *args, **kwargs</dt></dl>
+ <dl><dt><a name="-response_fixture_factory"><strong>response_fixture_factory</strong></a>(url, data)</dt></dl>
+</td></tr></table>
+</body></html>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import re
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-from pip.req import parse_requirements
+#from pip.req import parse_requirements
 
 
 TEST_REQUIRES = [
@@ -71,9 +71,12 @@ setup(
     packages=find_packages(exclude=('test*', )),
     package_dir={'betfair': 'betfair'},
     include_package_data=True,
-    install_requires=[
-        str(requirement.req)
-        for requirement in parse_requirements('requirements.txt')
+    # install_requires=[
+    #     str(requirement.req)
+    #     for requirement in parse_requirements('requirements.txt')
+    # ],
+    install_requires = [
+        line.strip() for line in open('requirements.txt')
     ],
     license=read('LICENSE'),
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import re
 import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-#from pip.req import parse_requirements
 
 
 TEST_REQUIRES = [
@@ -71,10 +70,6 @@ setup(
     packages=find_packages(exclude=('test*', )),
     package_dir={'betfair': 'betfair'},
     include_package_data=True,
-    # install_requires=[
-    #     str(requirement.req)
-    #     for requirement in parse_requirements('requirements.txt')
-    # ],
     install_requires = [
         line.strip() for line in open('requirements.txt')
     ],


### PR DESCRIPTION
Apparently Pip req.parse_requirements is not supposed to be called from outside pip, they're moving it in next version and had already changed it, breaking your setup.py.

source: Pip maintainers comment here: http://stackoverflow.com/questions/14399534/how-can-i-reference-requirements-txt-for-the-install-requires-kwarg-in-setuptool