### PR TITLE
Fix betfair.models.StartingPrices

### DIFF
--- a/betfair/models.py
+++ b/betfair/models.py
@@ -99,8 +99,8 @@ class PriceSize(BetfairModel):
 class StartingPrices(BetfairModel):
     near_price = Field(DataType(float))
     far_price = Field(DataType(float))
-    back_state_taken = Field(ModelType(PriceSize))
-    lay_liability_taken = Field(ModelType(PriceSize))
+    back_stake_taken = ListField(ModelType(PriceSize))
+    lay_liability_taken = ListField(ModelType(PriceSize))
     actual_SP = Field(DataType(float))
 
 


### PR DESCRIPTION
This fixes two minor errors with the StartingPrices model:

  1. Fix typo back_state_taken -> back_stake_taken
  2. Change back/lay stake taken attributes to be ListFields