### PR TITLE
Correct certificate generation information in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,15 +34,19 @@ simplifying this process. To create a self-signed certificate, run ::
 
     invoke ssl
 
-This will generate a file named ``betfair.pem`` in the ``certs`` directory.
+This will generate the following files in the ``certs`` directory ::
+
+    betfair.crt
+    betfair.csr
+    betfair.key
+    betfair.pem
+
 You can write SSL certificates to another directory by passing the
 ``--name`` parameter ::
 
     invoke ssl --name=path/to/certs/ssl
 
-This will generate a file named ``ssl.pem`` in the ``path/to/certs/``
-directory. Once you have generated the SSL certificate, you can upload the
-.pem file to Betfair at https://myaccount.betfair.com/accountdetails/mysecurity?showAPI=1.
+Once you have generated the files, you can upload the ``.crt`` file to Betfair at https://myaccount.betfair.com/accountdetails/mysecurity?showAPI=1.
 
 Examples
 --------


### PR DESCRIPTION
There were a few minor errors in the README file:

  1. The .crt file and not the .pem file should be uploaded to Betfair
  2. The link to the page to upload the .crt file was incorrect.
  3. Several files are generated by `invoke ssl` not just `betfair.pem`

This also includes some minor re-wording and re-formatting to make
the instructions clearer.

This fixes the following issue: https://github.com/jmcarp/betfair.py/issues/6