### PR TITLE
Add dependency on simplejson (== 3.6.5)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ INSTALL_REQUIRES = [
     'decorator>=3.4.2',
     'inflection>=0.3.0',
     'python-dateutil>=2.4.2',
+    'simplejson==3.6.5',
 ]
 TEST_REQUIRES = [
     'pytest',


### PR DESCRIPTION
requests will preferentially use simplejson over json from the standard
library if it is available:

https://github.com/kennethreitz/requests/blob/master/requests/compat.py#L25

simplejson is effectively the latest version of json, it's faster and
has the latest bugfixes for the library.