### PR TITLE
Change Runner.selection_id type to int

### DIFF
--- a/betfair/models.py
+++ b/betfair/models.py
@@ -138,7 +138,7 @@ class Match(BetfairModel):
 
 
 class Runner(BetfairModel):
-    selection_id = Field(DataType(float), required=True)
+    selection_id = Field(DataType(int), required=True)
     handicap = Field(DataType(float), required=True)
     status = Field(EnumType(constants.RunnerStatus), required=True)
     adjustment_factor = Field(DataType(float))


### PR DESCRIPTION
Previously Runner.selection_id was declared to be a float, however the
API documentation says that it is a long:

https://api.developer.betfair.com/services/webapps/docs/x/SIA6#BettingTypeDefinitions-Runner

This changes the declared data type in the model to int. int is used
over long as this maintains Python 3 compatability (in Python 2
int('<some number>') will return a long if the number is big enough
to require it).