### PR TITLE
Remove "license" argument from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
     package_dir={'betfair': 'betfair'},
     include_package_data=True,
     install_requires=INSTALL_REQUIRES,
-    license=read('LICENSE'),
     zip_safe=False,
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
"license" is only meant to be used if there isn't a classifier
available for the license the package is under, there is already one
for the MIT license and setup.py already declares it.

Additionaly, the LICENSE file is not packaged with the rest of the
library, and so `read('LICENSE')` fails when attempting to install
from pypi (meaning you cannot install 0.1.4 using
`pip install betfair.py` currently).

For example:

```bash
@:betfair.py$ pip install betfair.py
Downloading/unpacking betfair.py
  Downloading betfair.py-0.1.4.tar.gz
  Running setup.py (path:/example/build/betfair.py/setup.py) egg_info for package betfair.py
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/example/build/betfair.py/setup.py", line 79, in <module>
        license=read('LICENSE'),
      File "/example/build/betfair.py/setup.py", line 61, in read
        with open(fname) as fp:
    IOError: [Errno 2] No such file or directory: 'LICENSE'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/example/build/betfair.py/setup.py", line 79, in <module>

    license=read('LICENSE'),

  File "/example/build/betfair.py/setup.py", line 61, in read

    with open(fname) as fp:

IOError: [Errno 2] No such file or directory: 'LICENSE'

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /example/build/betfair.py
Storing debug log for failure in /.pip/pip.log
```