### PR TITLE
Distinct Exception  for not logged

### DIFF
--- a/betfair/exceptions.py
+++ b/betfair/exceptions.py
@@ -33,3 +33,12 @@ class BetfairAPIError(BetfairError):
             self.message = 'UNKNOWN'
             self.details = None
         super(BetfairAPIError, self).__init__(self.message)
+
+
+class NotLoggedIn(BetfairError):
+    """
+    exception raised if the user is not logged in
+    """
+    pass
+
+

--- a/betfair/utils.py
+++ b/betfair/utils.py
@@ -123,4 +123,4 @@ def requires_login(func, *args, **kwargs):
     self = args[0]
     if self.session_token:
         return func(*args, **kwargs)
-    raise exceptions.BetfairError('Not logged in')
+    raise exceptions.NotLoggedIn('Not logged in')


### PR DESCRIPTION
Distinct Exception (NotLoggedIn) for not logged in event, instead of generic BetfairError.