### PR TITLE
fix names in constants and models

### DIFF
--- a/betfair/constants.py
+++ b/betfair/constants.py
@@ -33,7 +33,7 @@ MatchProjection = Enum(
     'MatchProjection', [
         'NO_ROLLUP',
         'ROLLED_UP_BY_PRICE',
-        'ROLLED_UP_BY_AVERAGE_PRICE',
+        'ROLLED_UP_BY_AVG_PRICE',
     ]
 )
 

--- a/betfair/models.py
+++ b/betfair/models.py
@@ -193,8 +193,8 @@ class ExBestOffersOverrides(BetfairModel):
 
 class PriceProjection(BetfairModel):
     price_data = ListField(EnumType(constants.PriceData))
-    ex_best_offer_overrides = Field(ModelType(ExBestOffersOverrides))
-    virtualize = Field(DataType(bool))
+    ex_best_offers_overrides = Field(ModelType(ExBestOffersOverrides))
+    virtualise = Field(DataType(bool))
     rollover_stakes = Field(DataType(bool))
 
 
@@ -296,7 +296,7 @@ class CurrentOrderSummary(BetfairModel):
     persistence_type = Field(EnumType(constants.PersistenceType), required=True)
     order_type = Field(EnumType(constants.OrderType), required=True)
     placed_date = Field(datetime_type, required=True)
-    matched_date = Field(datetime_type, required=True)
+    matched_date = Field(datetime_type)
     average_price_matched = Field(DataType(float))
     size_matched = Field(DataType(float))
     size_remaining = Field(DataType(float))
@@ -328,7 +328,7 @@ class ClearedOrderSummary(BetfairModel):
     selection_id = Field(DataType(int))
     handicap = Field(DataType(float))
     bet_id = Field(DataType(six.text_type))
-    placed_data = Field(datetime_type)
+    placed_date = Field(datetime_type)
     persistence_type = Field(EnumType(constants.PersistenceType))
     order_type = Field(EnumType(constants.OrderType))
     side = Field(EnumType(constants.Side))
@@ -345,7 +345,7 @@ class ClearedOrderSummary(BetfairModel):
 
 
 class ClearedOrderSummaryReport(BetfairModel):
-    current_orders = ListField(ModelType(ClearedOrderSummary), required=True)
+    cleared_orders = ListField(ModelType(ClearedOrderSummary), required=True)
     more_available = Field(DataType(bool), required=True)
 
 


### PR DESCRIPTION
So I have created 2 patches with the most obvious fixes.

The fix in betfair/constants.py is needed if you want to use the recently introduced lean call to listMarketBook, see http://forum.bdp.betfair.com/showpost.php?p=11951&postcount=59

The others are merely fixes of names which where included in my old 'bulk' pull requests.

Note that in CurrentOrderSummary the attribute 'matched_date' is wrongly marked as required in the BF docs, but it says "when applicable" in the comment in the same docs.
In fact it depends on the parameters in the API call if this attribute is returned. So marking it as required leads to an exception in parsing the response if the attribute is not there.

Note that the two patches here are created from partial commits from my working branch which also include some more ambiguous changes that I found practical (see the old issues and pull requests), so it is not tested against the API but should work nonetheless because of the nature of the fixes.