### PR TITLE
fixes broken exception handling on http status code != ok.

### DIFF
--- a/betfair/exceptions.py
+++ b/betfair/exceptions.py
@@ -37,3 +37,12 @@ class ApiError(BetfairError):
             self.message = 'UNKNOWN'
             self.details = None
         super(ApiError, self).__init__(self.message)
+
+
+class ApiHttpError(BetfairError):
+
+    def __init__(self, response):
+        self.response = response
+        self.status_code = response.status_code
+        self.message = "error http return code: %s" % self.status_code
+        super(ApiHttpError, self).__init__(self.message)

--- a/betfair/utils.py
+++ b/betfair/utils.py
@@ -53,7 +53,7 @@ def check_status_code(response, codes=None):
         else lambda resp: resp.status_code in codes
     )
     if not checker(response):
-        raise exceptions.ApiError(response)
+        raise exceptions.ApiHttpError(response)
 
 
 def result_or_error(response):


### PR DESCRIPTION
the current handling of http error codes != ok is broken, so i fixed this with a new class explicit for this cases. the exception message contains the http status code, so does the exception object has an attribute for status_code.  