### PR TITLE
allows the Betfair object to take a custom request timeout value

### DIFF
--- a/betfair/betfair.py
+++ b/betfair/betfair.py
@@ -38,13 +38,14 @@ class Betfair(object):
     :param Session session: Optional Requests session
     """
     def __init__(self, app_key, cert_file, content_type='application/json', locale=None,
-                 session=None):
+                 session=None, request_timeout=None):
         self.app_key = app_key
         self.cert_file = cert_file
         self.content_type = content_type
         self.locale = locale
         self.session = session or requests.Session()
         self.session_token = None
+        self.request_timeout = request_timeout
 
     @property
     def identity_url(self):
@@ -67,6 +68,7 @@ class Betfair(object):
         response = self.session.post(
             os.path.join(self.identity_url, method),
             headers=self.headers,
+            timeout=self.request_timeout,
         )
         utils.check_status_code(response)
         data = response.json()
@@ -79,6 +81,7 @@ class Betfair(object):
             self.api_url,
             data=json.dumps(payload, cls=utils.BetfairEncoder),
             headers=self.headers,
+            timeout=self.request_timeout,
         )
         utils.check_status_code(response, codes=codes)
         result = utils.result_or_error(response)
@@ -104,6 +107,7 @@ class Betfair(object):
                 'X-Application': self.app_key,
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
+            timeout=self.request_timeout,
         )
         utils.check_status_code(response, [httplib.OK])
         data = response.json()


### PR DESCRIPTION
default http timeouts are a bit too long for most of my cases. This little change allow to set a custom "session_timeout" value, which is passed along to api requests. If timeout is reached a requests.exceptions. ConnectTimeout error is raised