### PR TITLE
Stop inflecting on each serializtion

### DIFF
--- a/betfair/meta/models.py
+++ b/betfair/meta/models.py
@@ -1,10 +1,31 @@
 # -*- coding: utf-8 -*-
 
-from schematics import models
+from schematics import types, models
+from six import add_metaclass
+import inflection
 
-from . import utils
+
+class AttributeCamelizingModelMeta(models.ModelMeta):
+    """A meta class that sets serialied_name and deserialize_from on class
+    schemactic type attributes to the camalized name of the attribute (unless
+    serialied_name or deserialize_from has already been specified)"""
+
+    def __new__(meta, name, bases, dct):
+        for k in dct:
+            v = dct[k]
+            if isinstance(v, types.BaseType):
+                camelized_name = inflection.camelize(k,
+                    uppercase_first_letter=False)
+                if v.serialized_name is None:
+                    v.serialized_name = camelized_name
+                if v.deserialize_from is None:
+                    v.deserialize_from = camelized_name
+
+        return super(AttributeCamelizingModelMeta, meta).__new__(meta, name,
+                                                                 bases, dct)
 
 
+@add_metaclass(AttributeCamelizingModelMeta)
 class BetfairModel(models.Model):
 
     def __init__(self, **data):
@@ -12,10 +33,5 @@ class BetfairModel(models.Model):
         self.import_data(data)
 
     def import_data(self, data, **kwargs):
-        data = utils.unserialize_dict(data)
         kwargs['strict'] = False
         return super(BetfairModel, self).import_data(data, **kwargs)
-
-    def serialize(self, *args, **kwargs):
-        data = super(BetfairModel, self).serialize(*args, **kwargs)
-        return utils.serialize_dict(data)

--- a/betfair/meta/types.py
+++ b/betfair/meta/types.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from schematics import types
-from schematics.types import compound
 from schematics.exceptions import ConversionError
 from schematics.exceptions import ValidationError
-
-from . import utils
 
 
 class DateTimeType(types.DateTimeType):
@@ -15,12 +12,6 @@ class DateTimeType(types.DateTimeType):
         '%Y-%m-%dT%H:%M:%S.%fZ',
         '%Y-%m-%dT%H:%M:%S',
     )
-
-
-class ModelType(compound.ModelType):
-
-    def export_loop(self, *args, **kwargs):
-        return utils.serialize_dict(super(ModelType, self).export_loop(*args, **kwargs))
 
 
 class EnumType(types.BaseType):

--- a/betfair/meta/utils.py
+++ b/betfair/meta/utils.py
@@ -17,6 +17,5 @@ def convert_dict(data, key_converter=None, value_converter=None):
     }
 
 
-unserialize_dict = functools.partial(convert_dict, key_converter=inflection.underscore)
 camelize = functools.partial(inflection.camelize, uppercase_first_letter=False)
 serialize_dict = functools.partial(convert_dict, key_converter=camelize)

--- a/betfair/models.py
+++ b/betfair/models.py
@@ -8,9 +8,9 @@ from schematics.types import StringType
 from schematics.types import BooleanType
 from schematics.types.compound import DictType
 from schematics.types.compound import ListType
+from schematics.types.compound import ModelType
 
 from betfair.meta.types import EnumType
-from betfair.meta.types import ModelType
 from betfair.meta.types import DateTimeType
 from betfair.meta.models import BetfairModel
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,12 +25,14 @@ FakeEnum = Enum(
     'TestEnum', [
         'val1',
         'val2',
+        'SOME_VALUE'
     ]
 )
 
 @pytest.mark.parametrize(['input', 'expected'], [
     ('val1', 'val1'),
     (FakeEnum.val1, 'val1'),
+    (FakeEnum.SOME_VALUE, 'SOME_VALUE')
 ])
 def test_enum_type(input, expected):
     class FakeModel(BetfairModel):


### PR DESCRIPTION
The attributes on the models are in snake case to conform to Python
conventions, however the keys they map to in JSON response from Betfair
are in camel case, e.g.

    class Event(BetfairModel):
        ...
        country_code = StringType()
        ...

is serialied to and from JSON like so:

    {"countryCode": "GB"}

Previously the names of the attributes were converted to and from camel
case on each serilization and deserialization using the inflection libary.
This is relatively slow and lots of redundant calls were made as one request
could contain multiple attributes with the same name and each one was
camelized separately.

The schematics library supports mapping attributes to and from keys with
different names, this is done by specifying the serialized_name and
deserialize_from parameters of attributes. Specifying these attribute
for every existing attribute would be cumersome and error prone. Also,
any new model in future would have to make sure to specify them too.

This adds a meta class to BetfairModel which sets the serialized_name and
deserialized from attributes (if not already specified) of class attributes.
Any BetfairModel attribute now can be specified in snake case but will
automatically be mapped to the correct camel case key. This happens once
per attribute per class, saving many calls to inflection and speeding up
serializating and deserialization.