### PR TITLE
Fix make_payload method (KeyError: endpoint)

### DIFF
--- a/betfair/utils.py
+++ b/betfair/utils.py
@@ -106,7 +106,7 @@ def make_payload(base, method, params):
     """
     payload = {
         'jsonrpc': '2.0',
-        'method': '{base}APING/v1.0/{endpoint}'.format(**locals()),
+        'method': '{base}APING/v1.0/{method}'.format(**locals()),
         'params': utils.serialize_dict(params),
         'id': 1,
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from schematics.exceptions import ValidationError
 from betfair import models
 from betfair import constants
 from betfair.utils import BetfairEncoder
+from betfair.utils import make_payload
 
 
 def test_encode_enum():
@@ -34,3 +35,10 @@ def test_encode_model_invalid():
     raw = {'model': models.MarketDescription()}
     with pytest.raises(ValidationError):
         json.dumps(raw, cls=BetfairEncoder)
+
+
+def test_make_payload():
+    result = make_payload('Sports', 'listMarketBook', {'some_param': 123})
+    assert result == {'jsonrpc': '2.0',
+                     'method': 'SportsAPING/v1.0/listMarketBook',
+                     'params': {'someParam': 123}, 'id': 1}


### PR DESCRIPTION
In 8e94168 make_payload was change to parameterise the 'method' of the
payload with `'{endpoint}'` rather then `'{0}'` from `**locals()`. There
is no 'endpoint' key in there - the correct key is 'method'. This changes
that format string to expect a 'method' key.