### PR TITLE
handling api and http error exceptions proposal

### DIFF
--- a/betfair/exceptions.py
+++ b/betfair/exceptions.py
@@ -27,16 +27,31 @@ class AuthError(BetfairError):
         super(AuthError, self).__init__(self.message)
 
 
-class ApiError(BetfairError):
+class ApiMetaError(BetfairError):
 
-    def __init__(self, response, data):
+    def __init__(self, response, message, details):
         self.response = response
         self.status_code = response.status_code
+        self.message = message
+        self.details = details
+        super(ApiMetaError, self).__init__(self.message)
+
+
+class ApiError(ApiMetaError):
+
+    def __init__(self, response, data):
         try:
             error_data = data['error']['data']['APINGException']
-            self.message = error_data.get('errorCode', 'UNKNOWN')
-            self.details = error_data.get('errorDetails')
+            message = error_data.get('errorCode', 'UNKNOWN')
+            details = error_data.get('errorDetails')
         except KeyError:
-            self.message = 'UNKNOWN'
-            self.details = None
-        super(ApiError, self).__init__(self.message)
+            message = 'UNKNOWN'
+            details = None
+        super(ApiError, self).__init__(response, message, details)
+
+
+class ApiHttpError(ApiMetaError):
+
+    def __init__(self, response):
+        super(ApiHttpError, self).__init__(response, "error http return code: %s" %
+                                           response.status_code, None)

--- a/betfair/utils.py
+++ b/betfair/utils.py
@@ -53,7 +53,7 @@ def check_status_code(response, codes=None):
         else lambda resp: resp.status_code in codes
     )
     if not checker(response):
-        raise exceptions.ApiError(response, response.json())
+        raise exceptions.ApiHttpError(response)
 
 
 def result_or_error(response):

--- a/tests/test_betfair.py
+++ b/tests/test_betfair.py
@@ -70,11 +70,11 @@ def test_login_error(client, login_failure):
 
 
 def test_login_bad_code(client, login_bad_code):
-    with pytest.raises(exceptions.ApiError) as excinfo:
+    with pytest.raises(exceptions.ApiHttpError) as excinfo:
         client.login('name', 'wrong')
     error = excinfo.value
     assert error.status_code == 422
-    assert error.message == 'UNKNOWN'
+    assert error.message == 'error http return code: 422'
 
 
 def test_keepalive_success(logged_in_client, keepalive_success):


### PR DESCRIPTION
This is a proposal of handling api and http errors according to discussion of pr #43 

includes two separate classes for api and http errors, but both exceptions are inherited from a ApiMetaError exception. 