### PR TITLE
Adding the missing field "bet_outcome"

### DIFF
--- a/betfair/models.py
+++ b/betfair/models.py
@@ -330,7 +330,6 @@ class ItemDescription(BetfairModel):
 
 
 class ClearedOrderSummary(BetfairModel):
-    bet_outcome = StringType()
     event_type_id = StringType()
     event_id = StringType()
     market_id = StringType()
@@ -351,6 +350,7 @@ class ClearedOrderSummary(BetfairModel):
     size_settled = FloatType()
     profit = FloatType()
     size_cancelled = FloatType()
+    bet_outcome = StringType()
 
 
 class ClearedOrderSummaryReport(BetfairModel):

--- a/betfair/models.py
+++ b/betfair/models.py
@@ -330,6 +330,7 @@ class ItemDescription(BetfairModel):
 
 
 class ClearedOrderSummary(BetfairModel):
+    bet_outcome = StringType()
     event_type_id = StringType()
     event_id = StringType()
     market_id = StringType()


### PR DESCRIPTION
Hey mate,
According the model definition at [betfair docs](http://docs.developer.betfair.com/docs/display/1smk3cen4v3lu3yomq5qye0ni/Betting+Type+Definitions#BettingTypeDefinitions-ClearedOrderSummary) for the model **ClearedOrderSummary**, it should contain also the **bet_outcome**.  I have added it to save you the pain. Works just fine for me  ;)