### PR TITLE
New Betfair non-interactive (bot) login endpoint

### DIFF
--- a/betfair/betfair.py
+++ b/betfair/betfair.py
@@ -17,7 +17,7 @@ from betfair import exceptions
 
 
 IDENTITY_URLS = collections.defaultdict(
-    lambda: 'https://identitysso.betfair.com/api/',
+    lambda: 'https://identitysso-cert.betfair.com/api/',
     italy='https://identitysso.betfair.it/api/',
 )
 

--- a/betfair/betfair.py
+++ b/betfair/betfair.py
@@ -18,7 +18,7 @@ from betfair import exceptions
 
 IDENTITY_URLS = collections.defaultdict(
     lambda: 'https://identitysso-cert.betfair.com/api/',
-    italy='https://identitysso.betfair.it/api/',
+    italy='https://identitysso-cert.betfair.it/api/',
 )
 
 API_URLS = collections.defaultdict(

--- a/tests/test_betfair.py
+++ b/tests/test_betfair.py
@@ -24,7 +24,7 @@ def test_client_init(client):
 
 @pytest.mark.parametrize(['locale', 'identity_url'], [
     (None, 'https://identitysso-cert.betfair.com/api/'),
-    ('australia', 'https://identitysso.betfair.com/api/'),
+    ('australia', 'https://identitysso-cert.betfair.com/api/'),
     ('italy', 'https://identitysso-cert.betfair.it/api/'),
 ])
 def test_identity_url(locale, identity_url):

--- a/tests/test_betfair.py
+++ b/tests/test_betfair.py
@@ -23,9 +23,9 @@ def test_client_init(client):
 
 
 @pytest.mark.parametrize(['locale', 'identity_url'], [
-    (None, 'https://identitysso.betfair.com/api/'),
+    (None, 'https://identitysso-cert.betfair.com/api/'),
     ('australia', 'https://identitysso.betfair.com/api/'),
-    ('italy', 'https://identitysso.betfair.it/api/'),
+    ('italy', 'https://identitysso-cert.betfair.it/api/'),
 ])
 def test_identity_url(locale, identity_url):
     client_ = betfair.Betfair('', '', locale=locale)


### PR DESCRIPTION
The previous endpoint (https://identitysso.betfair.com/api/certlogin) will be retired and no longer available after Thursday 20th December 2018.

The new endpoint is [https://identitysso-cert.betfair.com/api/]